### PR TITLE
[MASSEMBLY-775] remove false OS-specific warnings/errors

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/FileItemAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/FileItemAssemblyPhase.java
@@ -87,8 +87,6 @@ public class FileItemAssemblyPhase
 
             final String outputDirectory1 = fileItem.getOutputDirectory();
 
-            AssemblyFormatUtils.warnForPlatformSpecifics( getLogger(), outputDirectory1 );
-
             final String outputDirectory =
                 AssemblyFormatUtils.getOutputDirectory( outputDirectory1, configSource.getFinalName(), configSource,
                                                         AssemblyFormatUtils.moduleProjectInterpolator(

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddFileSetsTask.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddFileSetsTask.java
@@ -112,8 +112,6 @@ public class AddFileSetsTask
             destDirectory = fileSet.getDirectory();
         }
 
-        AssemblyFormatUtils.warnForPlatformSpecifics( logger, destDirectory );
-
         destDirectory =
             AssemblyFormatUtils.getOutputDirectory( destDirectory, configSource.getFinalName(), configSource,
                                                     AssemblyFormatUtils.moduleProjectInterpolator( moduleProject ),

--- a/src/main/java/org/apache/maven/plugins/assembly/utils/AssemblyFormatUtils.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/utils/AssemblyFormatUtils.java
@@ -476,38 +476,6 @@ public final class AssemblyFormatUtils
         return value;
     }
 
-    public static void warnForPlatformSpecifics( Logger logger, String destDirectory )
-    {
-        if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
-        {
-            if ( isLinuxRootReference( destDirectory ) )
-            {
-                logger.error( "OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference"
-                                  + " (starting with slash) " + destDirectory );
-            }
-            else if ( isWindowsPath( destDirectory ) )
-            {
-                logger.warn( "The assembly descriptor contains a *nix-specific root-relative-reference"
-                                 + " (starting with slash). This is non-portable and will fail on windows "
-                                 + destDirectory );
-            }
-        }
-        else
-        {
-            if ( isWindowsPath( destDirectory ) )
-            {
-                logger.error(
-                    "OS=Non-Windows and the assembly descriptor contains a windows-specific directory reference"
-                        + " (with a drive letter) " + destDirectory );
-            }
-            else if ( isLinuxRootReference( destDirectory ) )
-            {
-                logger.warn( "The assembly descriptor contains a filesystem-root relative reference,"
-                                 + " which is not cross platform compatible " + destDirectory );
-            }
-        }
-    }
-
     static boolean isWindowsPath( String destDirectory )
     {
         return ( destDirectory != null && destDirectory.length() >= 2 && destDirectory.charAt( 1 ) == ':' );


### PR DESCRIPTION
According to various references, "/" being an invalid directory separator on Windows was never true. Besides, the OS on which an assembly is generated and the OS on which it is consumed may differ, so blind checks of the build-time system are nonsensem. Just remove the whole thing.