### PR TITLE
[MASSEMBLY-617] add ability to give a fileSuffix to a FileSet

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/PrefixedArchivedFileSet.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/PrefixedArchivedFileSet.java
@@ -148,5 +148,10 @@ class PrefixedArchivedFileSet
     {
         return fileSet.getStreamTransformer();
     }
+    
+    public String getFileSuffix()
+    {
+        return fileSet.getFileSuffix();
+    }
 
 }

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/PrefixedFileSet.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/PrefixedFileSet.java
@@ -177,4 +177,9 @@ class PrefixedFileSet
     {
         return fileSet.getStreamTransformer();
     }
+    
+    public String getFileSuffix()
+    {
+        return fileSet.getFileSuffix();
+    }
 }

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDirectoryTask.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDirectoryTask.java
@@ -51,6 +51,8 @@ public class AddDirectoryTask
     private int directoryMode = -1;
 
     private int fileMode = -1;
+    
+    private String fileSuffix;
 
     public AddDirectoryTask( final File directory, InputStreamTransformer transformers )
     {
@@ -139,6 +141,7 @@ public class AddDirectoryTask
                     fs.setDirectory( directory );
                     fs.setIncludes( includesArray );
                     fs.setExcludes( excludesArray );
+                    fs.setFileSuffix( fileSuffix );
                     if ( transformer != null )
                     {
                         fs.setStreamTransformer( transformer );
@@ -206,5 +209,9 @@ public class AddDirectoryTask
     {
         this.useDefaultExcludes = useDefaultExcludes;
     }
-
+      
+    public void setFileSuffix( String fileSuffix ) 
+    {
+        this.fileSuffix = fileSuffix;
+    }
 }

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddFileSetsTask.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddFileSetsTask.java
@@ -165,6 +165,7 @@ public class AddFileSetsTask
             task.setExcludes( fileSet.getExcludes() );
             task.setIncludes( fileSet.getIncludes() );
             task.setOutputDirectory( destDirectory );
+            task.setFileSuffix( fileSet.getFileSuffix() );
 
             task.execute( archiver );
         }

--- a/src/main/mdo/assembly-component.mdo
+++ b/src/main/mdo/assembly-component.mdo
@@ -283,6 +283,16 @@
           <defaultValue>false</defaultValue>
           <type>boolean</type>
         </field>
+        <field>
+          <name>fileSuffix</name>
+          <version>3.2.0+</version>
+          <type>String</type>
+          <description>
+            <![CDATA[
+            Sets a suffix for copying  files in this fileSet. Example : test.xml => testSuffix.xml
+            ]]>
+          </description>
+        </field>
       </fields>
     </class>
     <class>

--- a/src/main/mdo/assembly.mdo
+++ b/src/main/mdo/assembly.mdo
@@ -403,6 +403,16 @@
           <defaultValue>false</defaultValue>
           <type>boolean</type>
         </field>
+        <field>
+          <name>fileSuffix</name>
+          <version>3.2.0+</version>
+          <type>String</type>
+          <description>
+            <![CDATA[
+            Sets a suffix for copying  files in this fileSet. Example : test.xml => testSuffix.xml
+            ]]>
+          </description>
+        </field>
       </fields>
     </class>
     <class>


### PR DESCRIPTION
Hi

In order to fix https://issues.apache.org/jira/browse/MASSEMBLY-617, I need to add a capability to add file suffix to a FileSet
This PR add this feature, but it need https://github.com/sonatype/plexus-archiver/pull/25 and https://github.com/sonatype/plexus-io/pull/7

Tell me if something goes wrong