### PR TITLE
MASSEMBLY-919: Fix dependency scope handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-dependency-tree</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-artifact-transfer</artifactId>
       <version>0.11.0</version>
     </dependency>

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/DependencySetAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/DependencySetAssemblyPhase.java
@@ -61,7 +61,6 @@ public class DependencySetAssemblyPhase
     @Requirement
     private DependencyResolver dependencyResolver;
 
-
     /**
      * Default constructor.
      */

--- a/src/main/java/org/apache/maven/plugins/assembly/artifact/ScopeBasedDependencySelector.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/artifact/ScopeBasedDependencySelector.java
@@ -1,0 +1,112 @@
+package org.apache.maven.plugins.assembly.artifact;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.artifact.Artifact;
+import org.sonatype.aether.collection.DependencyCollectionContext;
+import org.sonatype.aether.collection.DependencySelector;
+import org.sonatype.aether.graph.Dependency;
+
+/**
+ * Dependency selector which based on the hierarchy of scopes, calculates which dependency should be included or not.
+ *
+ */
+public class ScopeBasedDependencySelector implements DependencySelector
+{
+
+    private boolean compileScope;
+
+    private boolean runtimeScope;
+
+    private boolean testScope;
+
+    private boolean providedScope;
+
+    private boolean systemScope;
+
+    public ScopeBasedDependencySelector( String scope )
+    {
+        switch ( scope )
+        {
+            case Artifact.SCOPE_PROVIDED:
+                providedScope = true;
+                break;
+            case Artifact.SCOPE_SYSTEM:
+                systemScope = true;
+                break;
+            case Artifact.SCOPE_COMPILE:
+                systemScope = true;
+                providedScope = true;
+                compileScope = true;
+                break;
+            case Artifact.SCOPE_RUNTIME:
+                compileScope = true;
+                runtimeScope = true;
+                break;
+            case Artifact.SCOPE_COMPILE_PLUS_RUNTIME:
+                systemScope = true;
+                providedScope = true;
+                compileScope = true;
+                runtimeScope = true;
+                break;
+            case Artifact.SCOPE_RUNTIME_PLUS_SYSTEM:
+                systemScope = true;
+                compileScope = true;
+                runtimeScope = true;
+                break;
+            case Artifact.SCOPE_TEST:
+                systemScope = true;
+                providedScope = true;
+                compileScope = true;
+                runtimeScope = true;
+                testScope = true;
+                break;
+            default:
+                throw new RuntimeException( "Unknown scope specified:" + scope );
+        }
+    }
+
+    @Override
+    public boolean selectDependency ( Dependency dependency )
+    {
+        switch ( dependency.getScope() )
+        {
+            case Artifact.SCOPE_SYSTEM:
+                return systemScope;
+            case Artifact.SCOPE_PROVIDED:
+                return providedScope;
+            case Artifact.SCOPE_COMPILE:
+                return compileScope;
+            case Artifact.SCOPE_RUNTIME:
+                return runtimeScope;
+            case Artifact.SCOPE_TEST:
+                return testScope;
+            default:
+                throw new RuntimeException( "Unknown scope specified:" + dependency.getScope() + " for " + dependency );
+        }
+    }
+
+    @Override
+    public DependencySelector deriveChildSelector ( DependencyCollectionContext context )
+    {
+        return this;
+    }
+
+}

--- a/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
@@ -201,6 +201,12 @@ public class DefaultDependencyResolverTest
         runDependencyResolution( Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST, false, Artifact.SCOPE_TEST, false );
     }
 
+    public void test_2ndLevelDependencyResolution_provided_provided_test ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_PROVIDED, Artifact.SCOPE_PROVIDED, true, Artifact.SCOPE_TEST, false );
+    }
+
     private void runDependencyResolution(final String dependencySetScope, String dependencyScope, boolean added) throws DependencyResolutionException, ModelBuildingException
     {
         runDependencyResolution(dependencySetScope, dependencyScope, added, null, false);

--- a/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
@@ -18,13 +18,16 @@ package org.apache.maven.plugins.assembly.artifact;
  * specific language governing permissions and limitations
  * under the License.
  */
-
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -37,23 +40,40 @@ import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.building.FileModelSource;
+import org.apache.maven.model.building.ModelBuilder;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.plugin.testing.stubs.StubArtifactRepository;
 import org.apache.maven.plugins.assembly.AssemblerConfigurationSource;
 import org.apache.maven.plugins.assembly.model.DependencySet;
 import org.apache.maven.plugins.assembly.model.ModuleBinaries;
 import org.apache.maven.plugins.assembly.model.ModuleSet;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.codehaus.plexus.PlexusTestCase;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.easymock.classextension.EasyMockSupport;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.impl.ArtifactDescriptorReader;
+import org.sonatype.aether.repository.LocalArtifactRequest;
+import org.sonatype.aether.repository.LocalArtifactResult;
+import org.sonatype.aether.repository.LocalRepository;
+import org.sonatype.aether.repository.LocalRepositoryManager;
 
 public class DefaultDependencyResolverTest
     extends PlexusTestCase
 {
 
     private DefaultDependencyResolver resolver;
-
+    private DefaultArtifactDescriptorReader defaultArtifactDescriptorReader;
+    private Map<String, Model> modelCache = new HashMap<>();
+    
     @Override
     public void setUp()
         throws Exception
@@ -61,43 +81,169 @@ public class DefaultDependencyResolverTest
         super.setUp();
 
         resolver = (DefaultDependencyResolver) lookup( DependencyResolver.class );
+        defaultArtifactDescriptorReader = (DefaultArtifactDescriptorReader) lookup(ArtifactDescriptorReader.class);
+        modelCache.clear();
     }
-    
+
     protected MavenSession newMavenSession( MavenProject project )
+    {
+        return newMavenSession( project, LegacyLocalRepositoryManager.wrap( new StubArtifactRepository( "target/local-repo" ),
+                                                                                          null ) );
+    }
+
+    protected MavenSession newMavenSession( MavenProject project, LocalRepositoryManager repositoryManager )
     {
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         MavenExecutionResult result = new DefaultMavenExecutionResult();
 
         MavenRepositorySystemSession repoSession = new MavenRepositorySystemSession();
         
-        repoSession.setLocalRepositoryManager( LegacyLocalRepositoryManager.wrap( new StubArtifactRepository( "target/local-repo" ),
-                                                                                  null ) );
+        repoSession.setLocalRepositoryManager( repositoryManager );
         MavenSession session = new MavenSession( getContainer(), repoSession, request, result );
         session.setCurrentProject( project );
         session.setProjects( Arrays.asList( project ) );
         return session;
     }
 
-
-    public void test_getDependencySetResolutionRequirements_transitive()
-        throws DependencyResolutionException
+    protected MavenSession newMavenSession( MavenProject project, final EasyMockSupport nm ) throws ModelBuildingException
     {
+        LocalRepositoryManager mock = nm.createMock( LocalRepositoryManager.class );
+        expect( mock.find( (RepositorySystemSession) anyObject(), (LocalArtifactRequest) anyObject() ) )
+                .andAnswer( new IAnswer<LocalArtifactResult>() {
+                    @Override
+                    public LocalArtifactResult answer () throws Throwable
+                    {
+                        Object[] arguments = EasyMock.getCurrentArguments();
+                        LocalArtifactRequest localArtifactRequest = (LocalArtifactRequest) arguments[1];
+                        LocalArtifactResult result = new LocalArtifactResult( localArtifactRequest );
+                        org.sonatype.aether.artifact.Artifact artifact = localArtifactRequest.getArtifact();
+                        return result.setAvailable( true )
+                                .setFile( new File( artifact.getGroupId() + '.' + artifact.getArtifactId() + '.'
+                                        + artifact.getVersion() + '.' + artifact.getExtension() ) );
+                    }
+                } ).atLeastOnce();
+        expect( mock.getRepository() ).andReturn( new LocalRepository( new File( "dummy-repository" ) ) ).atLeastOnce();
+
+        ModelBuilder modelBuilder = nm.createMock( ModelBuilder.class );
+        expect( modelBuilder.build( (ModelBuildingRequest) anyObject() ) )
+                .andAnswer( new IAnswer<ModelBuildingResult>() {
+                    @Override
+                    public ModelBuildingResult answer () throws Throwable
+                    {
+                        ModelBuildingRequest argument = (ModelBuildingRequest) EasyMock.getCurrentArguments()[0];
+                        ModelBuildingResult modelBuildingResult = nm.createMock( ModelBuildingResult.class );
+                        File pomFile = ( (FileModelSource) argument.getModelSource() ).getPomFile();
+                        Model model = modelCache.get( pomFile.getName() );
+                        if ( model == null )
+                        {
+                            model = new Model();
+                        }
+                        expect( modelBuildingResult.getEffectiveModel() ).andReturn( model ).atLeastOnce();
+                        replay( modelBuildingResult );
+                        return modelBuildingResult;
+                    }
+                } ).atLeastOnce();
+        defaultArtifactDescriptorReader.setModelBuilder( modelBuilder );
+        return newMavenSession( project, mock );
+    }
+
+    public void test_getDependencySetResolutionRequirements_transitive ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( null, Artifact.SCOPE_COMPILE, true );
+    }
+
+    public void test_getDependencySetResolutionRequirements_transitive_with_test_dependency ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( null, Artifact.SCOPE_TEST, true );
+    }
+
+    public void test_getDependencySetResolutionRequirements_transitive_with_test_dependency_scope_runtime ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST, false );
+    }
+
+    public void test_getDependencySetResolutionRequirements_transitive_with_test_dependency_scope_compile_runtime ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_COMPILE_PLUS_RUNTIME, Artifact.SCOPE_TEST, false );
+    }
+
+    public void test_getDependencySetResolutionRequirements_transitive_with_test_dependency_scope_test ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_TEST, Artifact.SCOPE_TEST, true );
+    }
+
+    public void test_2ndLevelDependencyResolution_no_scope_compile_compile ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( null, Artifact.SCOPE_COMPILE, true, Artifact.SCOPE_COMPILE, true );
+    }
+
+    public void test_2ndLevelDependencyResolution_compile_compile_compile ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_COMPILE, Artifact.SCOPE_COMPILE, true, Artifact.SCOPE_COMPILE, true );
+    }
+
+    public void test_2ndLevelDependencyResolution_compile_test_compile ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST, false, Artifact.SCOPE_COMPILE, false );
+    }
+
+    public void test_2ndLevelDependencyResolution_compile_test_test ()
+            throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution( Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST, false, Artifact.SCOPE_TEST, false );
+    }
+
+    private void runDependencyResolution(final String dependencySetScope, String dependencyScope, boolean added) throws DependencyResolutionException, ModelBuildingException
+    {
+        runDependencyResolution(dependencySetScope, dependencyScope, added, null, false);
+    }
+
+    private void runDependencyResolution(final String dependencySetScope, String dependencyScope, boolean added, String secondLevelDependencyScope, boolean secondLevelDependencyAdded)
+        throws DependencyResolutionException, ModelBuildingException
+    {
+        final EasyMockSupport mm = new EasyMockSupport();
+
         final DependencySet ds = new DependencySet();
-        ds.setScope( Artifact.SCOPE_SYSTEM );
+        ds.setScope( dependencySetScope );
         ds.setUseTransitiveDependencies( true );
 
         final MavenProject project = createMavenProject( "main-group", "main-artifact", "1", null );
+        final Artifact mainArtifact = newArtifact( "main-group", "main-artifact", "1" );
+        final Artifact depArtifact = newArtifact( "dep-group", "dep-artifact", "2", dependencyScope );
 
-        Set<Artifact> dependencyArtifacts = new HashSet<>();
-        dependencyArtifacts.add( newArtifact( "g.id", "a-id", "1" ) );
-        Set<Artifact> artifacts = new HashSet<>( dependencyArtifacts );
-        artifacts.add( newArtifact( "g.id", "a-id-2", "2" ) );
-        project.setArtifacts( artifacts );
-        project.setDependencyArtifacts( dependencyArtifacts );
+        project.setArtifacts( Collections.singleton( mainArtifact ) );
+        project.setDependencyArtifacts( Collections.singleton( depArtifact ) );
+        project.setDependencies(
+                Collections.singletonList( newDependency( "dep-group", "dep-artifact", "2", dependencyScope ) ) );
+        Set<Artifact> expected = new HashSet<>();
+        expected.add( mainArtifact );
+        if (added) {
+            expected.add( depArtifact );
+        }
+        if (secondLevelDependencyScope != null) {
+            Model depModel = new Model();
+            depModel.addDependency(
+                    newDependency( "other-dep-group", "other-dep-artifact", "3", secondLevelDependencyScope ) );
+            modelCache.put( "dep-group.dep-artifact.2.pom", depModel );
+        }
+        if (secondLevelDependencyAdded) {
+            expected.add( newArtifact( "other-dep-group", "other-dep-artifact", "3", secondLevelDependencyScope ) );
+        }
+
+        MavenSession mavenSession = newMavenSession( project, mm );
+        mm.replayAll();
 
         final ResolutionManagementInfo info = new ResolutionManagementInfo();
-        resolver.updateDependencySetResolutionRequirements( ds, info, project );
-        assertEquals( artifacts, info.getArtifacts() );
+        resolver.updateDependencySetResolutionRequirements( ds, info, mavenSession, project );
+        assertEquals( expected, info.getArtifacts() );
     }
 
     public void test_getDependencySetResolutionRequirements_nonTransitive()
@@ -117,7 +263,7 @@ public class DefaultDependencyResolverTest
         project.setDependencyArtifacts( dependencyArtifacts );
 
         final ResolutionManagementInfo info = new ResolutionManagementInfo();
-        resolver.updateDependencySetResolutionRequirements( ds, info, project );
+        resolver.updateDependencySetResolutionRequirements( ds, info, newMavenSession( project ), project );
         assertEquals( dependencyArtifacts, info.getArtifacts() );
     }
 
@@ -169,8 +315,8 @@ public class DefaultDependencyResolverTest
         final MavenProject module2 =
             createMavenProject( "main-group", "module-2", "1", new File( rootDir, "module-2" ) );
 
-        Set<Artifact> module1Artifacts = Collections.singleton( newArtifact( "group.id", "module-1-dep", "1" ) );
-        Set<Artifact> module2Artifacts = Collections.singleton( newArtifact( "group.id", "module-2-dep", "1" ) );
+        Set<Artifact> module1Artifacts = Collections.singleton( newArtifact( "main-group", "module-1", "1" ) );
+        Set<Artifact> module2Artifacts = Collections.singleton( newArtifact( "main-group", "module-2", "1" ) );
         module1.setArtifacts( module1Artifacts );
         module2.setArtifacts( module2Artifacts );
 
@@ -219,10 +365,26 @@ public class DefaultDependencyResolverTest
         return project;
     }
 
-    private Artifact newArtifact( final String groupId, final String artifactId, final String version )
+    private Artifact newArtifact( final String groupId, final String artifactId, final String version) 
     {
-        return new DefaultArtifact( groupId, artifactId, VersionRange.createFromVersion( version ), "compile", "jar",
+        return newArtifact(groupId, artifactId, version, "compile");
+    }
+
+    private Artifact newArtifact( final String groupId, final String artifactId, final String version, final String scope )
+    {
+        return new DefaultArtifact( groupId, artifactId, VersionRange.createFromVersion( version ), scope, "jar",
                                     null, new DefaultArtifactHandler() );
+    }
+
+    private Dependency newDependency( final String groupId, final String artifactId, final String version, final String scope )
+    {
+        Dependency dep = new Dependency();
+        dep.setArtifactId( artifactId );
+        dep.setGroupId( groupId );
+        dep.setVersion( version );
+        dep.setScope( scope );
+        dep.setType( "jar" );
+        return dep;
     }
 
 }


### PR DESCRIPTION
The problem is that the assembly plugin collects every dependency, flatten the dependency hierarchy tree, and only after this, filter's out by scope. This will cause that if A has a test dependency B, which has a 'runtime' dependency C, C is treated as a runtime dependency of A, and it is included. The implemented fix is using proper tree walking, and checking eagerly the scope of the dependency.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MASSEMBLY) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MASSEMBLY-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MASSEMBLY-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

