### PR TITLE
[MASSEMBLY-874] maven-assembly plugin always downloads dependencies from net

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTask.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTask.java
@@ -41,6 +41,7 @@ import org.apache.maven.plugins.assembly.model.UnpackOptions;
 import org.apache.maven.plugins.assembly.utils.AssemblyFormatUtils;
 import org.apache.maven.plugins.assembly.utils.FilterUtils;
 import org.apache.maven.plugins.assembly.utils.TypeConversionUtils;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
@@ -180,7 +181,10 @@ public class AddDependencySetsTask
 
     private ProjectBuildingRequest getProjectBuildingRequest( AssemblerConfigurationSource configSource )
     {
-        return configSource.getMavenSession().getProjectBuildingRequest();
+        ProjectBuildingRequest pbr =
+            new DefaultProjectBuildingRequest( configSource.getMavenSession().getProjectBuildingRequest() );
+        pbr.setRemoteRepositories( project.getRemoteArtifactRepositories() );
+        return pbr;
     }
 
     private boolean isUnpackWithOptions( DependencySet dependencySet )

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/task/testutils/MockAndControlForAddDependencySetsTask.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/task/testutils/MockAndControlForAddDependencySetsTask.java
@@ -22,7 +22,10 @@ package org.apache.maven.plugins.assembly.archive.task.testutils;
 import junit.framework.Assert;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.plugins.assembly.AssemblerConfigurationSource;
 import org.apache.maven.plugins.assembly.artifact.DependencyResolutionException;
@@ -35,6 +38,7 @@ import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.codehaus.plexus.archiver.ArchivedFileSet;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
@@ -44,6 +48,9 @@ import org.easymock.classextension.EasyMockSupport;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
@@ -105,6 +112,35 @@ public class MockAndControlForAddDependencySetsTask
         expect( session.getSystemProperties() ).andReturn( new Properties() ).anyTimes();
         expect( session.getUserProperties() ).andReturn( new Properties() ).anyTimes();
         expect( session.getExecutionProperties() ).andReturn( new Properties() ).anyTimes();
+
+        expect( projectBuildingRequest.isProcessPlugins() )
+                .andReturn( false ).anyTimes();
+        expect( projectBuildingRequest.getProfiles() )
+                .andReturn( Collections.<Profile>emptyList() ).anyTimes();
+        expect( projectBuildingRequest.getActiveProfileIds() )
+                .andReturn( Collections.<String>emptyList() ).anyTimes();
+        expect( projectBuildingRequest.getInactiveProfileIds() )
+                .andReturn( Collections.<String>emptyList() ).anyTimes();
+        expect( projectBuildingRequest.getSystemProperties() )
+                .andReturn( new Properties() ).anyTimes();
+        expect( projectBuildingRequest.getUserProperties() )
+                .andReturn( new Properties() ).anyTimes();
+        expect( projectBuildingRequest.getRemoteRepositories() )
+                .andReturn( new ArrayList<ArtifactRepository>() ).anyTimes();
+        expect( projectBuildingRequest.getPluginArtifactRepositories() )
+                .andReturn( Collections.<ArtifactRepository>emptyList() ).anyTimes();
+        expect( projectBuildingRequest.getRepositorySession() )
+                .andReturn( new MavenRepositorySystemSession() ).anyTimes();
+        expect( projectBuildingRequest.getLocalRepository() )
+                .andReturn( new MavenArtifactRepository() ).anyTimes();
+        expect( projectBuildingRequest.getBuildStartTime() )
+                .andReturn( new Date() ).anyTimes();
+        expect( projectBuildingRequest.getProject() )
+                .andReturn( project ).anyTimes();
+        expect( projectBuildingRequest.isResolveDependencies() )
+                .andReturn( false ).anyTimes();
+        expect( projectBuildingRequest.getValidationLevel() )
+                .andReturn( ModelBuildingRequest.VALIDATION_LEVEL_STRICT ).anyTimes();
 
         expectGetSession( session );
     }


### PR DESCRIPTION
use main list of remote repositories when build dependency set.
Fix for https://issues.apache.org/jira/browse/MASSEMBLY-874
Logic of fix is somewhat similar to https://github.com/apache/maven-assembly-plugin/commit/d9a06f5559fadc6275db4b4d3dc49b0d81f77385 : set actual remote repositories inside `ProjectBuildingRequest`

See comment https://issues.apache.org/jira/browse/MASSEMBLY-874?focusedCommentId=17016987&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17016987

What I found out;
1. AddDependencySetsTask builds project (what for?) for each dependency artifact.
https://github.com/apache/maven-assembly-plugin/blob/master/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTask.java#L157
2. AddDependencySetsTask calls `DefaultProjectBuilder.build` method. This method need pom file to build project
https://github.com/apache/maven/blob/master/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java#L307
2. DefaultProjectBuilder resolves pom file via `DefaultRepositorySystem.resolveArtifact` call.
https://github.com/apache/maven/blob/master/maven-core/src/main/java/org/apache/maven/project/DefaultProjectBuilder.java#L318
3. Then it goes down to usage of `EnhancedLocalRepositoryManager.find` method here
https://github.com/apache/maven-resolver/blob/master/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java#L318
4. Implementation of this method do not just use artifact from local cache, but before usage is checks `_remote.repositories` file content and matches it with repositories.
![image](https://user-images.githubusercontent.com/741251/72556147-16224b80-38af-11ea-900d-f5392b606cb3.png)
https://github.com/apache/maven-resolver/blob/master/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java#L105
5. It uses file only if there is repository match.
From my case, described in JIRA comment, artifact `ipf-api` was downloaded from *shared* remote repository, but by default only _default_ repository is considered. Default repository by default it's *central* (see https://github.com/apache/maven/blob/master/maven-core/src/main/java/org/apache/maven/repository/RepositorySystem.java#L56), but we have mirror for it (called Nexus)

 - [*] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
