### PR TITLE
[MASSEMBLY-932] resource filtering skipped for resources in the current project

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/AssemblyProxyArchiver.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/AssemblyProxyArchiver.java
@@ -769,7 +769,7 @@ public class AssemblyProxyArchiver
             dfs.setIncludingEmptyDirectories( fs.isIncludingEmptyDirectories() );
             dfs.setPrefix( fs.getPrefix() );
             dfs.setUsingDefaultExcludes( fs.isUsingDefaultExcludes() );
-            dfs.setStreamTransformer(fs.getStreamTransformer());
+            dfs.setStreamTransformer( fs.getStreamTransformer() );
 
             delegate.addFileSet( dfs );
         }

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/AssemblyProxyArchiver.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/AssemblyProxyArchiver.java
@@ -769,6 +769,7 @@ public class AssemblyProxyArchiver
             dfs.setIncludingEmptyDirectories( fs.isIncludingEmptyDirectories() );
             dfs.setPrefix( fs.getPrefix() );
             dfs.setUsingDefaultExcludes( fs.isUsingDefaultExcludes() );
+            dfs.setStreamTransformer(fs.getStreamTransformer());
 
             delegate.addFileSet( dfs );
         }


### PR DESCRIPTION
Resource filtering skipped for resources in the current project

In AssemblyProxyArchive, when assemblyWorkPath.startsWith( fsPath ) is true the stream transformer is lost when creating a delegate file set

I can't submit a test case as my project is fairly involved and proprietary, but trying to upgrade from 2.4 to 3.2.0 stops substituting ${*} into the output file


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MASSEMBLY) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MASSEMBLY-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MASSEMBLY-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

