### PR TITLE
[MASSEMBLY-852] - directoryMode permissions are lost if include is present

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDirectoryTask.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDirectoryTask.java
@@ -79,6 +79,7 @@ public class AddDirectoryTask
         }
 
         final int oldDirMode = archiver.getOverrideDirectoryMode();
+        final int oldDefaultDirMode = archiver.getDefaultDirectoryMode();
         final int oldFileMode = archiver.getOverrideFileMode();
 
         boolean fileModeSet = false;
@@ -89,6 +90,7 @@ public class AddDirectoryTask
             if ( directoryMode != -1 )
             {
                 archiver.setDirectoryMode( directoryMode );
+                archiver.setDefaultDirectoryMode( directoryMode );
                 dirModeSet = true;
             }
 
@@ -157,6 +159,7 @@ public class AddDirectoryTask
             if ( dirModeSet )
             {
                 archiver.setDirectoryMode( oldDirMode );
+                archiver.setDefaultDirectoryMode( oldDefaultDirMode );
             }
 
             if ( fileModeSet )

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/task/AddDirectoryTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/task/AddDirectoryTaskTest.java
@@ -98,10 +98,12 @@ public class AddDirectoryTaskTest
     {
         final int dirMode = Integer.parseInt( "777", 8 );
         final int fileMode = Integer.parseInt( "777", 8 );
-        final int defaultDirMode = -1;
-        final int defaultFileMode = -1;
+        final int overrideDirMode = 755;
+        final int defaultDirMode = 722;
+        final int defaultFileMode = 711;
 
-        when( archiver.getOverrideDirectoryMode() ).thenReturn( defaultDirMode );
+        when( archiver.getDefaultDirectoryMode() ).thenReturn( defaultDirMode );
+        when( archiver.getOverrideDirectoryMode() ).thenReturn( overrideDirMode );
         when( archiver.getOverrideFileMode() ).thenReturn( defaultFileMode );
         
         AddDirectoryTask task = new AddDirectoryTask( temporaryFolder.getRoot() );
@@ -113,11 +115,14 @@ public class AddDirectoryTaskTest
         
         // result of easymock migration, should be assert of expected result instead of verifying methodcalls
         verify( archiver ).addFileSet( any( FileSet.class ) );
+        verify( archiver ).getDefaultDirectoryMode();
         verify( archiver ).getOverrideDirectoryMode();
         verify( archiver ).getOverrideFileMode();
+        verify( archiver ).setDefaultDirectoryMode( dirMode );
         verify( archiver ).setDirectoryMode( dirMode );
         verify( archiver ).setFileMode( fileMode );
-        verify( archiver ).setDirectoryMode( defaultDirMode );
+        verify( archiver ).setDefaultDirectoryMode( defaultDirMode );
+        verify( archiver ).setDirectoryMode( overrideDirMode );
         verify( archiver ).setFileMode( defaultFileMode );
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MASSEMBLY-852

The problem is essentially that ZipArchiver has 2 ways of setting directory mode ("override" and "default"), and we were only setting one of them. It is very unintuitive, but basically one is used when creating a directory outright (when a pattern matches it), and the other is used when creating the parent directories required by a matched file.

In the reporters case, the * ant pattern does not match the root directory so only the file is matched and the latter path is followed. There is a workaround to use a regex, which I posted on the ticket.

The safest thing for us to do is to set both the directory modes. We don't want to make a distinction between the two types.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MASSEMBLY) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MASSEMBLY-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MASSEMBLY-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

