### PR TITLE
[MASSEMBLY-957] Deprecate repository element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
 
   <properties>
     <javaVersion>7</javaVersion>
-    <mdoVersion>2.1.0</mdoVersion>
+    <mdoVersion>2.1.1</mdoVersion>
     <mavenVersion>3.2.5</mavenVersion>
     <slf4jVersion>1.7.5</slf4jVersion>
 
@@ -179,10 +179,10 @@ under the License.
       <version>4.2.1</version>
     </dependency>
     <dependency>
-    <groupId>commons-io</groupId>
-    <artifactId>commons-io</artifactId>
-    <version>2.6</version>
-  </dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/RepositoryAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/RepositoryAssemblyPhase.java
@@ -74,15 +74,18 @@ public class RepositoryAssemblyPhase implements AssemblyArchiverPhase, PhaseOrde
                          final AssemblerConfigurationSource configSource )
         throws ArchiveCreationException, AssemblyFormattingException, InvalidAssemblerConfigurationException
     {
-        LOGGER.warn( "" );
-        LOGGER.warn( "The <repository> element in assembly descriptor is deprecated," );
-        LOGGER.warn( "support for it will be removed. For details see:" );
-        LOGGER.warn( "https://issues.apache.org/jira/browse/MASSEMBLY-957" );
-        LOGGER.warn( "" );
-
         final List<Repository> repositoriesList = assembly.getRepositories();
 
         final File tempRoot = configSource.getTemporaryRootDirectory();
+
+        if ( !repositoriesList.isEmpty() )
+        {
+            LOGGER.warn( "" );
+            LOGGER.warn( "The <repository> element in assembly descriptor is deprecated," );
+            LOGGER.warn( "support for it will be removed. For details see:" );
+            LOGGER.warn( "https://issues.apache.org/jira/browse/MASSEMBLY-957" );
+            LOGGER.warn( "" );
+        }
 
         for ( final Repository repository : repositoriesList )
         {

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/RepositoryAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/RepositoryAssemblyPhase.java
@@ -74,6 +74,12 @@ public class RepositoryAssemblyPhase implements AssemblyArchiverPhase, PhaseOrde
                          final AssemblerConfigurationSource configSource )
         throws ArchiveCreationException, AssemblyFormattingException, InvalidAssemblerConfigurationException
     {
+        LOGGER.warn( "" );
+        LOGGER.warn( "The <repository> element in assembly descriptor is deprecated," );
+        LOGGER.warn( "support for it will be removed. For details see:" );
+        LOGGER.warn( "https://issues.apache.org/jira/browse/MASSEMBLY-957" );
+        LOGGER.warn( "" );
+
         final List<Repository> repositoriesList = assembly.getRepositories();
 
         final File tempRoot = configSource.getTemporaryRootDirectory();

--- a/src/main/mdo/assembly-component.mdo
+++ b/src/main/mdo/assembly-component.mdo
@@ -21,8 +21,8 @@
      Modello currently does not have capability to share files
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.8.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.8.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 http://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
        xml.namespace="http://maven.apache.org/ASSEMBLY-COMPONENT/${version}"
        xml.schemaLocation="http://maven.apache.org/xsd/assembly-component-${version}.xsd">
 
@@ -125,6 +125,7 @@
           </association>
           <description>
             <![CDATA[
+            <b>Deprecated since model version 2.1.1</b>.
             Specifies a set of repositories to include in the assembly. A
             repository is specified by providing one or more of
             &lt;repository&gt; subelements.
@@ -1027,6 +1028,7 @@
       <version>1.0.0+</version>
       <description>
         <![CDATA[
+        <b>Deprecated since model version 2.1.1</b>.
         Defines a Maven repository to be included in the assembly. The artifacts
         available to be included in a repository are your project's dependency
         artifacts. The repository created contains the needed metadata entries

--- a/src/main/mdo/assembly.mdo
+++ b/src/main/mdo/assembly.mdo
@@ -23,8 +23,8 @@
   to "assembly-component.mdo".
 -->
 
-<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.8.0 http://codehaus-plexus.github.io/modello/xsd/modello-1.8.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 http://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
        xml.namespace="http://maven.apache.org/ASSEMBLY/${version}"
        xml.schemaLocation="http://maven.apache.org/xsd/assembly-${version}.xsd">
 
@@ -233,6 +233,7 @@
           </association>
           <description>
             <![CDATA[
+            <b>Deprecated since model version 2.1.1</b>.
             Specifies which repository files to include in the assembly. A
             repository is specified by providing one or more of
             &lt;repository&gt; subelements.
@@ -1140,6 +1141,7 @@
       <version>1.0.0+</version>
       <description>
         <![CDATA[
+        <b>Deprecated since model version 2.1.1</b>.
         Defines a Maven repository to be included in the assembly. The artifacts
         available to be included in a repository are your project's dependency
         artifacts. The repository created contains the needed metadata entries


### PR DESCRIPTION
We have to deprecate ancient repository element in descriptor,
as it was done for Maven 2.0 (present since 1.0 version of this
plugin), but since Maven 3.0 things changed quite a lot.

---

https://issues.apache.org/jira/browse/MASSEMBLY-957
