### PR TITLE
[MASSEMBLY-941] improve IT description to ease failure investigations

### DIFF
--- a/src/it/projects/reproducible/verify.groovy
+++ b/src/it/projects/reproducible/verify.groovy
@@ -27,10 +27,31 @@ assert deployDir.exists()
 
 ZipFile zip = new ZipFile( new File( deployDir, "reproducible-1.0-src.zip" ) )
 StringBuilder sb = new StringBuilder()
+StringBuilder sb2 = new StringBuilder()
+int i = 0
 for( ZipArchiveEntry entry : zip.getEntries() )
 {
     sb.append( String.format("%o %s\n", entry.getUnixMode(), entry.getName() ) )
+    switch (++i)
+    {
+        case 1:
+            sb2.append( String.format(" directory: %o\n", entry.getUnixMode() ) )
+            break
+        case 9:
+            sb2.append( String.format("      file: %o\n", entry.getUnixMode() ) )
+            break
+        case 21:
+            sb2.append( String.format("executable: %o\n", entry.getUnixMode() ) )
+            break
+        default:
+            break
+    }
 }
+sb.append( '\n' )
+sb.append( 'unix modes summary:\n' )
+sb.append( sb2.toString() )
+sb.append( '\n' )
+sb.append( 'resulting sha1:\n' )
 for( String type : [ "zip", "jar", "tar" ] )
 {
     String name = "reproducible-1.0-src." + type + ".sha1"
@@ -40,9 +61,28 @@ for( String type : [ "zip", "jar", "tar" ] )
 effective = sb.toString()
 
 // 3 different reference results:
-// 1. Windows does not support executable flag
-// 2. on *nix, based on system configuration, group flag differs
+// 1. Windows does not support executable flag:
+//    => reference result is zip-content-win.txt: directory=40755, file=100644, executable=100644
+// 2. on *nix, based on umask system configuration, group write mode differs:
+//    - umask == 002: many Linux distro and MacOS create group writable files/directories:
+//      => reference result is zip-content-775.txt: directory=40775, file=100664, executable=100775
+//    - umask == 022: some Linux distros like Fedora is create group read-only files/directories:
+//      => reference result is zip-content-755.txt: directory=40755, file=100644, executable=100755
 reference = "zip-content-" + ( effective.contains( "644 executable" ) ? "win" : effective.contains( "0775" ) ? "775" : "755" ) + ".txt"
 content = new File( basedir, reference ).text.replace( "\r\n", "\n" )
 
-assert content == effective
+println( 'effective content:' )
+println( effective )
+println( 'comparing against reference ' + reference )
+
+index = content.indexOf( 'resulting sha1:' )
+contentMode = content.substring( 0, index )
+contentSha1 = content.substring( index )
+index = content.indexOf( 'resulting sha1:' )
+effectiveMode = effective.substring( 0, index )
+effectiveSha1 = effective.substring( index )
+
+assert contentMode == effectiveMode
+println( 'unix mode ok')
+assert contentSha1 == effectiveSha1
+println( 'sha1 ok')

--- a/src/it/projects/reproducible/zip-content-755.txt
+++ b/src/it/projects/reproducible/zip-content-755.txt
@@ -20,6 +20,13 @@
 100644 dir-d/d.txt
 100755 executable.txt
 100644 lowercase.txt
+
+unix modes summary:
+ directory: 40755
+      file: 100644
+executable: 100755
+
+resulting sha1:
 97d0ea3b4a87cd3ea78edd1c3c25914d69ea97f3 reproducible-1.0-src.zip.sha1
 a0c4cf1ed244e60221e12367f50ff676066b8e65 reproducible-1.0-src.jar.sha1
 bf93dd529253157352b87097d9d23eba8c9ca61a reproducible-1.0-src.tar.sha1

--- a/src/it/projects/reproducible/zip-content-775.txt
+++ b/src/it/projects/reproducible/zip-content-775.txt
@@ -20,6 +20,13 @@
 100664 dir-d/d.txt
 100775 executable.txt
 100664 lowercase.txt
+
+unix modes summary:
+ directory: 40775
+      file: 100664
+executable: 100775
+
+resulting sha1:
 50116502c6107740c2a35ef296b5abda08c5dec7 reproducible-1.0-src.zip.sha1
 cc7e3a984179f63d6b37bc86c61e9cc461c62288 reproducible-1.0-src.jar.sha1
 3efc10ec9c3099ba061e58d5b2a935ba643da237 reproducible-1.0-src.tar.sha1

--- a/src/it/projects/reproducible/zip-content-win.txt
+++ b/src/it/projects/reproducible/zip-content-win.txt
@@ -20,6 +20,13 @@
 100644 dir-d/d.txt
 100644 executable.txt
 100644 lowercase.txt
+
+unix modes summary:
+ directory: 40755
+      file: 100644
+executable: 100644
+
+resulting sha1:
 cb1dc226d702733bfa405b7090b74ab7e77bf39e reproducible-1.0-src.zip.sha1
 3b31d88a36985f526fb3fe6ba5987387e4887f23 reproducible-1.0-src.jar.sha1
 b85f960069d6a444f928a87761b63fde60ea687d reproducible-1.0-src.tar.sha1


### PR DESCRIPTION
trying to understand with @cstamas why current IT fails on his Fedora distribution, that has 022 umask by default

notice: reference `zip-content-755.txt` fiel has been created on an Ubuntu release, that has 002 umask by default, by setting by hand umask to 022: perhaps this action is not sufficient to match a real Fedora result...