### PR TITLE
Fix swallowed I/O exceptions by replacing PrintWriter with (OutputStreamWriter/BufferedWriter)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
@@ -19,11 +19,11 @@
 package org.apache.maven.plugins.assembly.filter;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -75,10 +75,11 @@ abstract class AbstractLineAggregatingHandler implements ContainerDescriptorHand
                 f = Files.createTempFile("assembly-" + fname, ".tmp").toFile();
                 f.deleteOnExit();
 
-                try (PrintWriter writer =
-                        new PrintWriter(new OutputStreamWriter(Files.newOutputStream(f.toPath()), getEncoding()))) {
+                try (BufferedWriter writer =
+                        new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(f.toPath()), getEncoding()))) {
                     for (final String line : entry.getValue()) {
-                        writer.println(line);
+                        writer.write(line);
+                        writer.newLine();
                     }
                 }
             } catch (final IOException e) {


### PR DESCRIPTION
Fixes : #1275

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
`PrintWriter` suppresses `IOException` by design. Instead of propagating errors, it silently captures them and sets an internal error flag. As a result, any I/O failure during write operations can go unnoticed unless `checkError()` is explicitly invoked.

While the usage of PrintWriter in `DefaultMessageHolder` is safe (since it writes to an in-memory `StringWriter`, which cannot throw `IOException`), its usage in `AbstractLineAggregatingHandler` is problematic because that class performs actual I/O operations. This could cause write failures to be ignored, leading to incomplete or lost log output without any visibility into the underlying issue.

✅ Solution

Replaced `PrintWriter` with `BufferedWriter` in `AbstractLineAggregatingHandler` so that I/O errors are surfaced immediately via thrown exceptions.
