### PR TITLE
disable Reproducible Builds if enabled by default

### DIFF
--- a/src/it/projects/bugs/massembly-891/pom.xml
+++ b/src/it/projects/bugs/massembly-891/pom.xml
@@ -34,6 +34,7 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>x</project.build.outputTimestamp>
   </properties>
 
   <build>


### PR DESCRIPTION
as it changes output timestamp with Maven 3.10 and Maven 4, where RB is active by default (super-POM)

@cstamas FYI, this is the root cause of m-assembly-IT failure with Maven 3.10.0-SNAPSHOT

```
assert log4jApi.getEntry(cls).time == jarWithDeps.getEntry(cls).time
       |        |        |    |    |  |           |        |    |
       |        |        |    |    |  |           |        |    318207600000
       |        |        |    |    |  |           |        'org/apache/logging/log4j/util/StackLocator.class'
       |        |        |    |    |  |           org/apache/logging/log4j/util/StackLocator.class
       |        |        |    |    |  massembly891-0.0.1-SNAPSHOT-jar-with-dependencies.jar@cd392ef
       |        |        |    |    false
       |        |        |    1676693766000
       |        |        'org/apache/logging/log4j/util/StackLocator.class'
       |        org/apache/logging/log4j/util/StackLocator.class
       log4j-api-2.20.0.jar@1fcddc4

*** end build.log for: projects/bugs/massembly-891/pom.xml ***

[ERROR] -------------------------------------------------
[ERROR] 
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 1, Failed: 1, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------
[ERROR] The following builds failed:
[ERROR] *  projects/bugs/massembly-891/pom.xml
[INFO] -------------------------------------------------
```