### PR TITLE
Fix ITs for Maven 4 compat

### DIFF
--- a/src/it/projects/dependency-sets/massembly-1008/verify.groovy
+++ b/src/it/projects/dependency-sets/massembly-1008/verify.groovy
@@ -16,22 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+def expectedFilenames = null
 
-import java.io.*;
-
-def expectedFilenames = [
-        "aopalliance-1.0.jar",
-        "checker-qual-3.12.0.jar",
-        "error_prone_annotations-2.7.1.jar",
-        "failureaccess-1.0.1.jar",
-        "guava-31.0.1-jre.jar",
-        "guice-6.0.0.jar",
-        "j2objc-annotations-1.3.jar",
-        "jakarta.inject-api-2.0.1.jar",
-        "javax.inject-1.jar",
-        "jsr305-3.0.2.jar",
-        "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
-]
+if (mavenVersion.startsWith('4.')) {
+  expectedFilenames = [
+          "aopalliance-1.0.jar",
+          "checker-qual-3.12.0.jar",
+          "error_prone_annotations-2.18.0.jar", // comes from guava 32.0.0-jre dependency runtime-dependency (not the test one)
+          "failureaccess-1.0.1.jar",
+          "guava-31.0.1-jre.jar",
+          "guice-6.0.0.jar",
+          "j2objc-annotations-1.3.jar",
+          "jakarta.inject-api-2.0.1.jar",
+          "javax.inject-1.jar",
+          "jsr305-3.0.1.jar", // funny that this is lower than in Maven 3
+          "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+  ]
+} else {
+  expectedFilenames = [
+          "aopalliance-1.0.jar",
+          "checker-qual-3.12.0.jar",
+          "error_prone_annotations-2.7.1.jar",
+          "failureaccess-1.0.1.jar",
+          "guava-31.0.1-jre.jar",
+          "guice-6.0.0.jar",
+          "j2objc-annotations-1.3.jar",
+          "jakarta.inject-api-2.0.1.jar",
+          "javax.inject-1.jar",
+          "jsr305-3.0.2.jar",
+          "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+  ]
+}
 
 File assemblyBasedir = new File( basedir, "target/massembly-1008-1-bin/" )
 

--- a/src/it/projects/dependency-sets/massembly-969/pom.xml
+++ b/src/it/projects/dependency-sets/massembly-969/pom.xml
@@ -30,7 +30,7 @@ under the License.
     <version>1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javafx.version>20</javafx.version>
+        <javafx.version>26</javafx.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/it/projects/dependency-sets/massembly-969/verify.groovy
+++ b/src/it/projects/dependency-sets/massembly-969/verify.groovy
@@ -16,20 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import java.io.*;
-
-def expectedFilenames = [ "javafx-base-20.jar",
-  "javafx-controls-20-linux.jar",
-  "javafx-media-20-linux.jar",
-  "javafx-web-20.jar",
-  "javafx-base-20-linux.jar",
-  "javafx-graphics-20-linux.jar",
-  "javafx-swing-20.jar",
-  "javafx-web-20-linux.jar",
-  "javafx-controls-20.jar",
-  "javafx-media-20.jar",
-  "javafx-swing-20-linux.jar"
+def expectedFilenames = [ "javafx-base-26.jar",
+  "javafx-controls-26-linux.jar",
+  "javafx-media-26-linux.jar",
+  "javafx-web-26.jar",
+  "javafx-base-26-linux.jar",
+  "javafx-graphics-26-linux.jar",
+  "javafx-swing-26.jar",
+  "javafx-web-26-linux.jar",
+  "javafx-controls-26.jar",
+  "javafx-media-26.jar",
+  "javafx-swing-26-linux.jar"
 ]
 
 File assemblyBasedir = new File( basedir, "target/massembly-969-1-bin/" )

--- a/src/it/projects/mojo-configuration/massembly-291/test.properties
+++ b/src/it/projects/mojo-configuration/massembly-291/test.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-altDeploymentRepository=test::default::file://${project.build.directory}/deploy
+altDeploymentRepository=test::default::file:./deploy

--- a/src/it/projects/mojo-configuration/massembly-291/verify.groovy
+++ b/src/it/projects/mojo-configuration/massembly-291/verify.groovy
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+String base = "./deploy/org/test/massembly-291/1/massembly-291-1";
 
-import java.io.*;
-
-String base = "target/deploy/org/test/massembly-291/1/massembly-291-1";
 File pom = new File( basedir, base + ".pom" );
 File zip = new File( basedir, base + ".zip" );
 File tgz = new File( basedir, base + ".tar.gz" );

--- a/src/it/projects/mojo-configuration/massembly-301/test.properties
+++ b/src/it/projects/mojo-configuration/massembly-301/test.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-altDeploymentRepository=test::default::file://${project.build.directory}/deploy
+altDeploymentRepository=test::default::file:./deploy

--- a/src/it/projects/mojo-configuration/massembly-301/verify.groovy
+++ b/src/it/projects/mojo-configuration/massembly-301/verify.groovy
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-import java.io.*;
+String base = "./deploy/org/test/massembly-301/1/massembly-301-1";
 
-String base = "target/deploy/org/test/massembly-301/1/massembly-301-1";
 File jar = new File( basedir, base + ".jar" );
 File zip = new File( basedir, base + ".zip" );
 File tgz = new File( basedir, base + ".tar.gz" );


### PR DESCRIPTION
Changes extracted in own PR, as requested in #1311.

Local build with Maven 3.9.16 and admin rights (due this symlink case)

```
D:\Github\Maven\maven-assembly-plugin>mvn clean verify -Prun-its -V
Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5)
Maven home: C:\apache-maven-3.9.16
Java version: 25.0.2, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-25
Default locale: de_DE, platform encoding: UTF-8
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
[INFO] Scanning for projects...


[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 148, Failed: 0, Errors: 0, Skipped: 2
[INFO] -------------------------------------------------
[WARNING] The following builds were skipped:
[WARNING] *  projects\bugs\massembly-731\pom.xml
[WARNING] *  projects\file-modes\file-set-fileMode\pom.xml
[INFO] -------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:19 min
[INFO] Finished at: 2026-06-14T14:18:03+02:00
[INFO] ------------------------------------------------------------------------
```



Local build with Maven 4.0.0-SNAPSHOT and admin rights (due this symlink case)

```
D:\Github\Maven\maven-assembly-plugin>mvn --version
Apache Maven 4.0.0-SNAPSHOT (8bedea9479918bdac71455635f0c51a2b5730f05)
Maven home: C:\apache-maven-4.0.x-self
Java version: 25.0.2, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-25
Default locale: de_DE, platform encoding: UTF-8, time zone: Europe/Berlin
OS name: "windows 11", version: "10.0", arch: "amd64", family: "winnt"


[INFO] Build Summary:
[INFO]   Passed: 148, Failed: 0, Errors: 0, Skipped: 2
[INFO] -------------------------------------------------
[WARNING] The following builds were skipped:
[WARNING] *  projects\bugs\massembly-731\pom.xml
[WARNING] *  projects\file-modes\file-set-fileMode\pom.xml
[INFO] -------------------------------------------------
[INFO] --------------------------------------------------------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] --------------------------------------------------------------------------------------------------------------------------
[INFO] Total time:  10:53 min
[INFO] Finished at: 2026-06-14T16:00:39+02:00
[INFO] --------------------------------------------------------------------------------------------------------------------------

```

Interesting that Maven 4 is almost three minutes slower.