### PR TITLE
[MASSEMBLY-953] Honor useAllReactorProjects regardless of reactor order

### DIFF
--- a/src/it/projects/bugs/massembly-953/distribution/pom.xml
+++ b/src/it/projects/bugs/massembly-953/distribution/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>distribution</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>test-module2</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>distro-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/bin.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-953/distribution/src/assembly/bin.xml
+++ b/src/it/projects/bugs/massembly-953/distribution/src/assembly/bin.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>bin</id>
+
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <includeBaseDirectory>true</includeBaseDirectory>
+
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>test:test-*:*</include>
+      </includes>
+      <binaries>
+        <includeDependencies>false</includeDependencies>
+        <unpack>false</unpack>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+</assembly>

--- a/src/it/projects/bugs/massembly-953/invoker.properties
+++ b/src/it/projects/bugs/massembly-953/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean package

--- a/src/it/projects/bugs/massembly-953/pom.xml
+++ b/src/it/projects/bugs/massembly-953/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>test-bom</artifactId>
+    <version>1.0</version>
+    <relativePath>test-bom/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>test-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>test-bom</module>
+    <module>test-module1</module>
+    <module>test-module2</module>
+    <module>distribution</module>
+  </modules>
+</project>

--- a/src/it/projects/bugs/massembly-953/test-bom/pom.xml
+++ b/src/it/projects/bugs/massembly-953/test-bom/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>test-bom</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+</project>

--- a/src/it/projects/bugs/massembly-953/test-module1/pom.xml
+++ b/src/it/projects/bugs/massembly-953/test-module1/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>test-module1</artifactId>
+</project>

--- a/src/it/projects/bugs/massembly-953/test-module1/src/main/resources/module.txt
+++ b/src/it/projects/bugs/massembly-953/test-module1/src/main/resources/module.txt
@@ -1,0 +1,4 @@
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0.

--- a/src/it/projects/bugs/massembly-953/test-module2/pom.xml
+++ b/src/it/projects/bugs/massembly-953/test-module2/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>test-module2</artifactId>
+</project>

--- a/src/it/projects/bugs/massembly-953/test-module2/src/main/resources/module.txt
+++ b/src/it/projects/bugs/massembly-953/test-module2/src/main/resources/module.txt
@@ -1,0 +1,4 @@
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0.

--- a/src/it/projects/bugs/massembly-953/verify.groovy
+++ b/src/it/projects/bugs/massembly-953/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+def archive = new File(basedir, "distribution/target/distribution-1.0-bin.zip")
+assert archive.isFile()
+
+def expectedFiles = [
+        "distribution-1.0/test-module1-1.0.jar",
+        "distribution-1.0/test-module2-1.0.jar"
+] as Set
+
+def zip = new ZipFile(archive)
+try {
+    def actualFiles = zip.entries().findAll { !it.directory }.collect { it.name } as Set
+    assert actualFiles == expectedFiles
+} finally {
+    zip.close()
+}

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
@@ -121,21 +121,19 @@ public class ModuleSetAssemblyPhase implements AssemblyArchiverPhase, PhaseOrder
     public static Set<MavenProject> getModuleProjects(
             final ModuleSet moduleSet, final AssemblerConfigurationSource configSource, final Logger logger)
             throws ArchiveCreationException {
+        final List<MavenProject> reactorProjects = configSource.getReactorProjects();
         final Set<MavenProject> moduleProjects;
 
         if (moduleSet.isUseAllReactorProjects()) {
-            moduleProjects = new LinkedHashSet<>(configSource.getReactorProjects());
+            moduleProjects = new LinkedHashSet<>(reactorProjects);
         } else {
+            final MavenProject project = configSource.getProject();
             try {
                 moduleProjects = ProjectUtils.getProjectModules(
-                        configSource.getProject(),
-                        configSource.getReactorProjects(),
-                        moduleSet.isIncludeSubModules(),
-                        logger);
+                        project, reactorProjects, moduleSet.isIncludeSubModules(), logger);
             } catch (final IOException e) {
                 throw new ArchiveCreationException(
-                        "Error retrieving module-set for project: "
-                                + configSource.getProject().getId() + ": " + e.getMessage(),
+                        "Error retrieving module-set for project: " + project.getId() + ": " + e.getMessage(),
                         e);
             }
         }

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
@@ -133,8 +133,7 @@ public class ModuleSetAssemblyPhase implements AssemblyArchiverPhase, PhaseOrder
                         project, reactorProjects, moduleSet.isIncludeSubModules(), logger);
             } catch (final IOException e) {
                 throw new ArchiveCreationException(
-                        "Error retrieving module-set for project: " + project.getId() + ": " + e.getMessage(),
-                        e);
+                        "Error retrieving module-set for project: " + project.getId() + ": " + e.getMessage(), e);
             }
         }
 

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
@@ -121,24 +121,22 @@ public class ModuleSetAssemblyPhase implements AssemblyArchiverPhase, PhaseOrder
     public static Set<MavenProject> getModuleProjects(
             final ModuleSet moduleSet, final AssemblerConfigurationSource configSource, final Logger logger)
             throws ArchiveCreationException {
-        MavenProject project = configSource.getProject();
-        Set<MavenProject> moduleProjects = null;
+        final Set<MavenProject> moduleProjects;
 
         if (moduleSet.isUseAllReactorProjects()) {
-            if (!moduleSet.isIncludeSubModules()) {
-                moduleProjects = new LinkedHashSet<>(configSource.getReactorProjects());
-            }
-
-            project = configSource.getReactorProjects().get(0);
-        }
-
-        if (moduleProjects == null) {
+            moduleProjects = new LinkedHashSet<>(configSource.getReactorProjects());
+        } else {
             try {
                 moduleProjects = ProjectUtils.getProjectModules(
-                        project, configSource.getReactorProjects(), moduleSet.isIncludeSubModules(), logger);
+                        configSource.getProject(),
+                        configSource.getReactorProjects(),
+                        moduleSet.isIncludeSubModules(),
+                        logger);
             } catch (final IOException e) {
                 throw new ArchiveCreationException(
-                        "Error retrieving module-set for project: " + project.getId() + ": " + e.getMessage(), e);
+                        "Error retrieving module-set for project: "
+                                + configSource.getProject().getId() + ": " + e.getMessage(),
+                        e);
             }
         }
 

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhaseTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhaseTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -614,6 +615,38 @@ class ModuleSetAssemblyPhaseTest {
         // result of easymock migration, should be assert of expected result instead of verifying methodcalls
         verify(configSource).getReactorProjects();
         verify(configSource, atLeastOnce()).getProject();
+    }
+
+    @Test
+    void getModuleProjectsShouldUseAllReactorProjectsRegardlessOfReactorOrder() throws Exception {
+        final MavenProject parent = createProject("group", "parent", "version", null);
+
+        final Model aggregatorModel = new Model();
+        aggregatorModel.setGroupId("group");
+        aggregatorModel.setArtifactId("aggregator");
+        aggregatorModel.setVersion("version");
+
+        final MavenProject aggregator = new MavenProject(aggregatorModel);
+        aggregator.setFile(new File(temporaryFolder, "aggregator/pom.xml"));
+
+        final MavenProject module = createProject("group", "module", "version", aggregator);
+        final MavenProject distribution = createProject("group", "distribution", "version", aggregator);
+
+        final List<MavenProject> projects = Arrays.asList(parent, aggregator, module, distribution);
+
+        final AssemblerConfigurationSource configSource = mock(AssemblerConfigurationSource.class);
+        when(configSource.getReactorProjects()).thenReturn(projects);
+        when(configSource.getProject()).thenReturn(distribution);
+
+        final ModuleSet moduleSet = new ModuleSet();
+        moduleSet.setUseAllReactorProjects(true);
+        moduleSet.setIncludeSubModules(true);
+
+        final Set<MavenProject> moduleProjects =
+                ModuleSetAssemblyPhase.getModuleProjects(moduleSet, configSource, logger);
+
+        assertEquals(new LinkedHashSet<>(projects), moduleProjects);
+        verify(configSource).getReactorProjects();
     }
 
     @Test

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhaseTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhaseTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -645,7 +644,7 @@ class ModuleSetAssemblyPhaseTest {
         final Set<MavenProject> moduleProjects =
                 ModuleSetAssemblyPhase.getModuleProjects(moduleSet, configSource, logger);
 
-        assertEquals(new LinkedHashSet<>(projects), moduleProjects);
+        assertEquals(projects, new ArrayList<>(moduleProjects));
         verify(configSource).getReactorProjects();
     }
 


### PR DESCRIPTION
Fixes #1162.

## Summary

Honor `<useAllReactorProjects>true</useAllReactorProjects>` independently of
reactor ordering.

The attached reproducer has a root aggregator that inherits from a BOM which
is also part of the reactor. Maven therefore sorts the non-aggregating BOM
before the root project. The assembly is produced by a distribution module
and is expected to contain both reactor module JARs.

## Root cause

`ModuleSetAssemblyPhase.getModuleProjects()` treated
`reactorProjects.get(0)` as the aggregation root when
`useAllReactorProjects` and `includeSubModules` were both enabled. When the
first reactor project was the BOM, recursive module discovery returned no
projects and the assembly failed with `archive cannot be empty`.

When `useAllReactorProjects` is enabled, the implementation now starts with
the complete ordered reactor and applies the existing include/exclude
filters. Module discovery from the current project is unchanged when that
option is disabled.

The integration test reproduces the BOM-first ordering and verifies that the
resulting archive contains both module JARs. A focused unit test covers the
reactor-order-independent selection.

## Validation

- Maven 3: `mvn -Prun-its clean verify`
  - 269 unit tests passed.
  - 151 Invoker builds passed.
- Maven 4: focused `clean verify` for the setup project and MASSEMBLY-953
  reproducer.
  - 269 unit tests passed.
  - Both Invoker builds passed.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
