### PR TITLE
[MASSEMBLY-958] Clarify dependency set resolution semantics

### DIFF
--- a/src/main/mdo/assembly-component.mdo
+++ b/src/main/mdo/assembly-component.mdo
@@ -387,7 +387,9 @@
       <version>1.0.0+</version>
       <description>
         A dependencySet allows inclusion and exclusion of project dependencies
-        in the assembly.
+        in the assembly. Dependency sets are evaluated against the project's
+        dependency graph after Maven dependency conflict resolution; include
+        patterns do not create separate dependency-resolution roots.
       </description>
       <fields>
         <field>

--- a/src/main/mdo/assembly.mdo
+++ b/src/main/mdo/assembly.mdo
@@ -509,7 +509,9 @@
       <version>1.0.0+</version>
       <description>
         A dependencySet allows inclusion and exclusion of project dependencies
-        in the assembly.
+        in the assembly. Dependency sets are evaluated against the project's
+        dependency graph after Maven dependency conflict resolution; include
+        patterns do not create separate dependency-resolution roots.
       </description>
       <fields>
         <field>


### PR DESCRIPTION
Fixes #1163.

## Summary

Clarify that dependency sets are evaluated against the project's dependency
graph after Maven dependency conflict resolution, and that include patterns do
not create separate dependency-resolution roots.

## Motivation

The `useTransitiveDependencies` and `useTransitiveFiltering` descriptions can
be read as if the dependencies matching a dependency set's includes are
resolved as an independent graph. In practice, Maven first mediates the
assembly project's complete dependency graph. The Assembly Plugin then applies
dependency-set filters to the surviving artifacts and dependency trails.

As a result, a direct project dependency can supersede the same artifact
reached transitively through an included dependency. The surviving direct
artifact no longer has the included dependency in its trail and is not selected
through transitive filtering.

The clarification is added to both the assembly and assembly-component model
descriptions so their generated reference documentation remains consistent.

## Validation

- `mvn -q verify`
- Confirmed that the generated Java model and both generated XSDs contain the
  clarification.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
  No runtime behavior changes; this pull request only updates generated model documentation.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).
  Integration tests were not rerun for this documentation-only change.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
