### PR TITLE
[MASSEMBLY-948] Resolve module dependencies with Maven Resolver

### DIFF
--- a/src/it/projects/bugs/massembly-830/pom.xml
+++ b/src/it/projects/bugs/massembly-830/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>massembly-830</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <!-- This artifact is relocated to org.apache.axis:axis-ant:1.4. -->
+      <groupId>axis</groupId>
+      <artifactId>axis-ant</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/dist.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-830/src/assembly/dist.xml
+++ b/src/it/projects/bugs/massembly-830/src/assembly/dist.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>dist</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>true</useProjectArtifact>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/src/it/projects/bugs/massembly-830/verify.groovy
+++ b/src/it/projects/bugs/massembly-830/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+def archive = new File(basedir, "target/massembly-830-1.0-SNAPSHOT-dist.zip")
+assert archive.isFile()
+
+def zip = new ZipFile(archive)
+try {
+    def files = zip.entries().findAll { !it.directory }*.name as Set
+    assert files == [
+        "lib/axis-ant-1.4.jar",
+        "lib/massembly-830-1.0-SNAPSHOT.jar"
+    ] as Set
+} finally {
+    zip.close()
+}

--- a/src/it/projects/bugs/massembly-948/application/pom.xml
+++ b/src/it/projects/bugs/massembly-948/application/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-948</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>application</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>direct-dependency</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/bugs/massembly-948/direct-dependency/pom.xml
+++ b/src/it/projects/bugs/massembly-948/direct-dependency/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-948</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>direct-dependency</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>transitive-dependency</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/bugs/massembly-948/distribution/pom.xml
+++ b/src/it/projects/bugs/massembly-948/distribution/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-948</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>distribution</artifactId>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/bin.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-948/distribution/src/assembly/bin.xml
+++ b/src/it/projects/bugs/massembly-948/distribution/src/assembly/bin.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>bin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>test:application</include>
+        <include>test:empty-pom</include>
+      </includes>
+      <binaries>
+        <outputDirectory>modules</outputDirectory>
+        <outputFileNameMapping>${module.artifactId}.${module.extension}</outputFileNameMapping>
+        <unpack>false</unpack>
+        <dependencySets>
+          <dependencySet>
+            <outputDirectory>dependencies</outputDirectory>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
+          </dependencySet>
+        </dependencySets>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+</assembly>

--- a/src/it/projects/bugs/massembly-948/empty-pom/pom.xml
+++ b/src/it/projects/bugs/massembly-948/empty-pom/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-948</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>empty-pom</artifactId>
+  <packaging>pom</packaging>
+</project>

--- a/src/it/projects/bugs/massembly-948/pom.xml
+++ b/src/it/projects/bugs/massembly-948/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>massembly-948</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>transitive-dependency</module>
+    <module>direct-dependency</module>
+    <module>application</module>
+    <module>distribution</module>
+    <!-- This POM must remain after the assembly module to reproduce MASSEMBLY-948. -->
+    <module>empty-pom</module>
+  </modules>
+</project>

--- a/src/it/projects/bugs/massembly-948/transitive-dependency/pom.xml
+++ b/src/it/projects/bugs/massembly-948/transitive-dependency/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-948</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>transitive-dependency</artifactId>
+</project>

--- a/src/it/projects/bugs/massembly-948/verify.groovy
+++ b/src/it/projects/bugs/massembly-948/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+def archive = new File(basedir, "distribution/target/distribution-1-bin.zip")
+assert archive.isFile()
+
+def zip = new ZipFile(archive)
+try {
+    def files = zip.entries().findAll { !it.directory }*.name as Set
+    assert files == ["modules/application.jar", "dependencies/direct-dependency.jar"] as Set
+} finally {
+    zip.close()
+}

--- a/src/main/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolver.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolver.java
@@ -186,17 +186,12 @@ public class DefaultDependencyResolver implements DependencyResolver {
                 continue;
             }
 
-            Set<Artifact> dependencyArtifacts = null;
-            if (set.isUseTransitiveDependencies()) {
-                try {
-                    // we need resolve project again according to requested scope
-                    dependencyArtifacts = resolveTransitive(systemSession, set.getScope(), project);
-                } catch (org.eclipse.aether.resolution.DependencyResolutionException e) {
-                    throw new DependencyResolutionException(e.getMessage(), e);
-                }
-            } else {
-                // FIXME remove using deprecated method
-                dependencyArtifacts = project.getDependencyArtifacts();
+            final Set<Artifact> dependencyArtifacts;
+            try {
+                dependencyArtifacts =
+                        resolveDependencies(systemSession, set.getScope(), project, set.isUseTransitiveDependencies());
+            } catch (org.eclipse.aether.resolution.DependencyResolutionException e) {
+                throw new DependencyResolutionException(e.getMessage(), e);
             }
 
             requirements.addArtifacts(dependencyArtifacts);
@@ -209,17 +204,17 @@ public class DefaultDependencyResolver implements DependencyResolver {
         }
     }
 
-    private Set<Artifact> resolveTransitive(
-            RepositorySystemSession repositorySession, String scope, MavenProject project)
+    private Set<Artifact> resolveDependencies(
+            RepositorySystemSession repositorySession, String scope, MavenProject project, boolean transitive)
             throws org.eclipse.aether.resolution.DependencyResolutionException {
 
         // scope dependency filter
-        DependencyFilter scoopeDependencyFilter = DependencyFilterUtils.classpathFilter(scope);
+        DependencyFilter scopeDependencyFilter = DependencyFilterUtils.classpathFilter(scope);
 
         // get project dependencies filtered by requested scope
         List<Dependency> dependencies = project.getDependencies().stream()
                 .map(d -> RepositoryUtils.toDependency(d, repositorySession.getArtifactTypeRegistry()))
-                .filter(d -> scoopeDependencyFilter.accept(new DefaultDependencyNode(d), null))
+                .filter(d -> scopeDependencyFilter.accept(new DefaultDependencyNode(d), null))
                 .collect(Collectors.toList());
 
         List<Dependency> managedDependencies = Optional.ofNullable(project.getDependencyManagement())
@@ -235,7 +230,9 @@ public class DefaultDependencyResolver implements DependencyResolver {
         collectRequest.setDependencies(dependencies);
         collectRequest.setRootArtifact(RepositoryUtils.toArtifact(project.getArtifact()));
 
-        DependencyRequest request = new DependencyRequest(collectRequest, scoopeDependencyFilter);
+        DependencyFilter resolutionFilter = (node, parents) ->
+                scopeDependencyFilter.accept(node, parents) && (transitive || isDirectDependency(node, parents));
+        DependencyRequest request = new DependencyRequest(collectRequest, resolutionFilter);
 
         DependencyResult dependencyResult = repositorySystem.resolveDependencies(repositorySession, request);
 
@@ -264,7 +261,9 @@ public class DefaultDependencyResolver implements DependencyResolver {
                 if (dependency != null) {
                     Artifact artifact = aetherToMavenArtifacts.computeIfAbsent(
                             dependency.getArtifact(), RepositoryUtils::toArtifact);
-                    if (artifact.isResolved() && artifact.getFile() != null) {
+                    if ((transitive || isDirectDependency(stack))
+                            && artifact.isResolved()
+                            && artifact.getFile() != null) {
                         List<String> depTrail = new ArrayList<>();
                         stack.descendingIterator().forEachRemaining(depTrail::add);
                         artifact.setDependencyTrail(depTrail);
@@ -279,5 +278,26 @@ public class DefaultDependencyResolver implements DependencyResolver {
         });
 
         return artifacts;
+    }
+
+    private static boolean isDirectDependency(Deque<String> stack) {
+        // The stack contains only the project and current node for direct dependencies.
+        return stack.size() == 2;
+    }
+
+    private static boolean isDirectDependency(DependencyNode node, List<DependencyNode> parents) {
+        int depth = parents == null ? 0 : parents.size();
+
+        // Maven Resolver 2.0.13 includes the node itself in the parent list, unlike Resolver 1.x and newer 2.x.
+        if (parents != null) {
+            for (DependencyNode parent : parents) {
+                if (parent == node) {
+                    depth--;
+                    break;
+                }
+            }
+        }
+
+        return depth <= 1;
     }
 }

--- a/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
@@ -157,7 +157,6 @@ class DefaultDependencyResolverTest {
         ds.setUseTransitiveDependencies(false);
 
         final MavenProject project = createMavenProject("main-group", "empty-pom", "1", null);
-        project.setDependencyArtifacts(null);
 
         DependencyResult dependencyResult = new DependencyResult(new DependencyRequest());
         dependencyResult.setRoot(new DefaultDependencyNode((Dependency) null));
@@ -251,7 +250,6 @@ class DefaultDependencyResolverTest {
         final Artifact pomArtifact = newArtifact(groupId, artifactId, version);
         project.setArtifact(pomArtifact);
         project.setArtifacts(new HashSet<>());
-        project.setDependencyArtifacts(new HashSet<>());
 
         project.setFile(new File(basedir, "pom.xml"));
 

--- a/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolverTest.java
@@ -40,10 +40,12 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -51,6 +53,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -113,21 +116,56 @@ class DefaultDependencyResolverTest {
     @Test
     void getDependencySetResolutionRequirementsNonTransitive() throws Exception {
         final DependencySet ds = new DependencySet();
-        ds.setScope(Artifact.SCOPE_SYSTEM);
+        ds.setScope(Artifact.SCOPE_RUNTIME);
         ds.setUseTransitiveDependencies(false);
 
         final MavenProject project = createMavenProject("main-group", "main-artifact", "1", null);
 
-        Set<Artifact> dependencyArtifacts = new HashSet<>();
-        dependencyArtifacts.add(newArtifact("g.id", "a-id", "1"));
-        Set<Artifact> artifacts = new HashSet<>(dependencyArtifacts);
-        artifacts.add(newArtifact("g.id", "a-id-2", "2"));
-        project.setArtifacts(artifacts);
-        project.setDependencyArtifacts(dependencyArtifacts);
+        Artifact directArtifact = newArtifact("g.id", "direct", "1");
+        DefaultDependencyNode directNode = new DefaultDependencyNode(new Dependency(
+                new org.eclipse.aether.artifact.DefaultArtifact("g.id:direct:1").setFile(new File(".")), "runtime"));
+        DefaultDependencyNode transitiveNode = new DefaultDependencyNode(new Dependency(
+                new org.eclipse.aether.artifact.DefaultArtifact("g.id:transitive:1").setFile(new File(".")),
+                "runtime"));
+        directNode.setChildren(Collections.singletonList(transitiveNode));
+
+        DependencyResult dependencyResult = new DependencyResult(new DependencyRequest());
+        DefaultDependencyNode rootDependencyNode = new DefaultDependencyNode((Dependency) null);
+        rootDependencyNode.setChildren(Collections.singletonList(directNode));
+        dependencyResult.setRoot(rootDependencyNode);
+
+        when(repositorySystem.resolveDependencies(eq(systemSession), any())).thenReturn(dependencyResult);
 
         final ResolutionManagementInfo info = new ResolutionManagementInfo();
         resolver.updateDependencySetResolutionRequirements(systemSession, ds, info, project);
-        assertEquals(dependencyArtifacts, info.getArtifacts());
+        assertEquals(Collections.singleton(directArtifact), info.getArtifacts());
+
+        ArgumentCaptor<DependencyRequest> requestCaptor = ArgumentCaptor.forClass(DependencyRequest.class);
+        verify(repositorySystem).resolveDependencies(eq(systemSession), requestCaptor.capture());
+        DependencyFilter filter = requestCaptor.getValue().getFilter();
+
+        assertTrue(filter.accept(directNode, Collections.singletonList(rootDependencyNode)));
+        assertTrue(filter.accept(directNode, Arrays.asList(directNode, rootDependencyNode)));
+        assertFalse(filter.accept(transitiveNode, Arrays.asList(directNode, rootDependencyNode)));
+        assertFalse(filter.accept(transitiveNode, Arrays.asList(transitiveNode, directNode, rootDependencyNode)));
+    }
+
+    @Test
+    void getDependencySetResolutionRequirementsNonTransitiveWithoutDependencies() throws Exception {
+        final DependencySet ds = new DependencySet();
+        ds.setScope(Artifact.SCOPE_SYSTEM);
+        ds.setUseTransitiveDependencies(false);
+
+        final MavenProject project = createMavenProject("main-group", "empty-pom", "1", null);
+        project.setDependencyArtifacts(null);
+
+        DependencyResult dependencyResult = new DependencyResult(new DependencyRequest());
+        dependencyResult.setRoot(new DefaultDependencyNode((Dependency) null));
+        when(repositorySystem.resolveDependencies(eq(systemSession), any())).thenReturn(dependencyResult);
+
+        final ResolutionManagementInfo info = new ResolutionManagementInfo();
+        resolver.updateDependencySetResolutionRequirements(systemSession, ds, info, project);
+        assertTrue(info.getArtifacts().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1158.

## Summary

Replace the deprecated `MavenProject.getDependencyArtifacts()` lookup used by
module-set dependency resolution with Maven Resolver.

This prevents a `NullPointerException` for reactor modules where Maven does not
populate the legacy dependency-artifact collection, including `pom`-packaging
projects. It also preserves the intended `useTransitiveDependencies` behavior:
direct reactor dependencies are included when the option is disabled, while
their transitive dependencies are omitted.

## Implementation

- Resolve module dependencies from the project's dependency graph through
  Maven Resolver.
- Select only depth-one dependency nodes for non-transitive module sets.
- Account for the dependency-node parent-list shapes used by Maven Resolver
  1.x and 2.x.
- Add unit coverage for missing legacy dependency artifacts and direct
  dependency selection.
- Add an Invoker reproducer with a multi-module reactor containing a
  `pom`-packaging module, and verify the exact archive contents.

## Compatibility and verification

- Maven 3.9.16: `mvn -Prun-its clean verify` passed (269 unit tests and 151
  Invoker builds).
- Maven 4.0.0-rc-5: `mvn clean verify` passed (269 unit tests).
- The processed regression project was also run directly with Maven 4.0.0-rc-5
  and Maven 3.6.3; both produced the expected direct-dependency-only archive.

The Maven 4 outer Invoker run is currently affected by Maven Invoker 3.10.1
passing `-D maven.repo.local=...` as two arguments, which Maven 4 rejects. This
is independent of the plugin change; the same processed integration-test
project passes when Maven receives the correctly formed
`-Dmaven.repo.local=...` argument.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
