### PR TITLE
[MASSEMBLY-940] Resolve dependencies of selected modules only

### DIFF
--- a/src/it/projects/bugs/massembly-940/distribution/pom.xml
+++ b/src/it/projects/bugs/massembly-940/distribution/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-940</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>distribution</artifactId>
+  <packaging>pom</packaging>
+
+  <!-- These dependencies put the assembly project after both module trees in the reactor. -->
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>selected-module</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>unrelated-module</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/bin.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-940/distribution/src/assembly/bin.xml
+++ b/src/it/projects/bugs/massembly-940/distribution/src/assembly/bin.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>bin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>test:selected-module</include>
+      </includes>
+      <binaries>
+        <outputDirectory>implicit</outputDirectory>
+        <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+        <unpack>false</unpack>
+        <includeDependencies>true</includeDependencies>
+      </binaries>
+    </moduleSet>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>test:selected-module</include>
+      </includes>
+      <binaries>
+        <outputDirectory>explicit</outputDirectory>
+        <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+        <unpack>false</unpack>
+        <includeDependencies>false</includeDependencies>
+        <dependencySets>
+          <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useProjectAttachments>false</useProjectAttachments>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+          </dependencySet>
+        </dependencySets>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+</assembly>

--- a/src/it/projects/bugs/massembly-940/pom.xml
+++ b/src/it/projects/bugs/massembly-940/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>massembly-940</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>selected-dependency</module>
+    <module>selected-module</module>
+    <module>unrelated-dependency</module>
+    <module>unrelated-module</module>
+    <module>distribution</module>
+  </modules>
+</project>

--- a/src/it/projects/bugs/massembly-940/selected-dependency/pom.xml
+++ b/src/it/projects/bugs/massembly-940/selected-dependency/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-940</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>selected-dependency</artifactId>
+</project>

--- a/src/it/projects/bugs/massembly-940/selected-dependency/src/main/resources/selected-dependency.txt
+++ b/src/it/projects/bugs/massembly-940/selected-dependency/src/main/resources/selected-dependency.txt
@@ -1,0 +1,1 @@
+selected dependency

--- a/src/it/projects/bugs/massembly-940/selected-module/pom.xml
+++ b/src/it/projects/bugs/massembly-940/selected-module/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-940</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>selected-module</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>selected-dependency</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/bugs/massembly-940/selected-module/src/main/resources/selected-module.txt
+++ b/src/it/projects/bugs/massembly-940/selected-module/src/main/resources/selected-module.txt
@@ -1,0 +1,1 @@
+selected module

--- a/src/it/projects/bugs/massembly-940/unrelated-dependency/pom.xml
+++ b/src/it/projects/bugs/massembly-940/unrelated-dependency/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-940</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>unrelated-dependency</artifactId>
+</project>

--- a/src/it/projects/bugs/massembly-940/unrelated-dependency/src/main/resources/unrelated-dependency.txt
+++ b/src/it/projects/bugs/massembly-940/unrelated-dependency/src/main/resources/unrelated-dependency.txt
@@ -1,0 +1,1 @@
+unrelated dependency

--- a/src/it/projects/bugs/massembly-940/unrelated-module/pom.xml
+++ b/src/it/projects/bugs/massembly-940/unrelated-module/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>massembly-940</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>unrelated-module</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>unrelated-dependency</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/bugs/massembly-940/unrelated-module/src/main/resources/unrelated-module.txt
+++ b/src/it/projects/bugs/massembly-940/unrelated-module/src/main/resources/unrelated-module.txt
@@ -1,0 +1,1 @@
+unrelated module

--- a/src/it/projects/bugs/massembly-940/verify.groovy
+++ b/src/it/projects/bugs/massembly-940/verify.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+def archive = new File(basedir, "distribution/target/distribution-1-bin.zip")
+assert archive.isFile()
+
+def zip = new ZipFile(archive)
+try {
+    def files = zip.entries().findAll { !it.directory }*.name as Set
+    def expected = [
+        "implicit/selected-module.jar",
+        "implicit/selected-dependency-1.jar",
+        "explicit/selected-module.jar",
+        "explicit/selected-dependency-1.jar"
+    ] as Set
+    assert files == expected: "Expected ${expected}, found ${files}"
+} finally {
+    zip.close()
+}

--- a/src/main/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolver.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/artifact/DefaultDependencyResolver.java
@@ -93,12 +93,7 @@ public class DefaultDependencyResolver implements DependencyResolver {
         Map<DependencySet, Set<Artifact>> result = new LinkedHashMap<>();
 
         for (DependencySet dependencySet : dependencySets) {
-
-            final MavenProject currentProject = configSource.getProject();
-
             final ResolutionManagementInfo info = new ResolutionManagementInfo();
-            updateDependencySetResolutionRequirements(
-                    configSource.getMavenSession().getRepositorySession(), dependencySet, info, currentProject);
             updateModuleSetResolutionRequirements(moduleSet, dependencySet, info, configSource);
 
             result.put(dependencySet, info.getArtifacts());
@@ -149,13 +144,11 @@ public class DefaultDependencyResolver implements DependencyResolver {
                 }
             }
 
-            if (binaries.isIncludeDependencies()) {
-                updateDependencySetResolutionRequirements(
-                        configSource.getMavenSession().getRepositorySession(),
-                        dependencySet,
-                        requirements,
-                        projects.toArray(new MavenProject[0]));
-            }
+            updateDependencySetResolutionRequirements(
+                    configSource.getMavenSession().getRepositorySession(),
+                    dependencySet,
+                    requirements,
+                    projects.toArray(new MavenProject[0]));
         }
     }
 


### PR DESCRIPTION
Fixes #1146.

## Summary

Resolve nested module-set dependency sets from the selected module projects
instead of from the project producing the assembly.

The regression test contains selected and unrelated module trees. It verifies
both the dependency set implied by `includeDependencies=true` and an explicitly
configured nested dependency set with `includeDependencies=false`. In both
cases, the archive must contain only the selected module and its dependency.

## Root cause

The module-set overload of `DefaultDependencyResolver.resolveDependencySets()`
first added dependencies of the assembly project. It added dependencies of the
selected modules only when `includeDependencies` was enabled. This caused
unrelated dependencies of the assembly project to leak into nested dependency
sets and prevented explicit nested dependency sets from resolving selected
module dependencies when `includeDependencies` was disabled.

Module-set dependency resolution now uses only the projects selected by the
module set. Explicit nested dependency sets are resolved independently of the
`includeDependencies` shortcut. When that option is disabled and no explicit
sets exist, `ModuleSetAssemblyPhase.getDependencySets()` still returns an empty
list, so no dependencies are added.

The change retains the per-dependency-set isolation introduced for
MASSEMBLY-619 and the scope-aware Maven Resolver implementation introduced for
MASSEMBLY-1008. The integration tests for both earlier fixes continue to pass.

## Compatibility and verification

- Maven 3.9.16: `mvn -Prun-its clean verify` passed with 268 unit tests and all
  151 Invoker builds.
- Maven 4.0.0-rc-5: `mvn clean verify` passed with 268 unit tests.
- The processed MASSEMBLY-940 integration-test reactor was run directly with
  Maven 4.0.0-rc-5 and produced the expected archive contents.

The Maven 4 outer Invoker run is currently affected by Maven Invoker 3.10.1
passing `-D maven.repo.local=...` as two arguments. This is independent of this
change; the same processed integration-test project passes when Maven receives
the correctly formed `-Dmaven.repo.local=...` argument.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
  This reactor-dependent behavior is covered by an Invoker integration test that fails without the runtime change.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
