### PR TITLE
[MASSEMBLY-947] Normalize CR line endings to CRLF

### DIFF
--- a/src/it/projects/file-sets/multimodule-win-lineEndings/child/pom.xml
+++ b/src/it/projects/file-sets/multimodule-win-lineEndings/child/pom.xml
@@ -25,6 +25,7 @@ under the License.
     <groupId>org.apache.maven.plugin.assembly.test</groupId>
     <artifactId>it-project-parent</artifactId>
     <version>1</version>
+    <relativePath>../../../../it-project-parent/pom.xml</relativePath>
   </parent>
   
   <artifactId>child</artifactId>

--- a/src/it/projects/file-sets/multimodule-win-lineEndings/setup.groovy
+++ b/src/it/projects/file-sets/multimodule-win-lineEndings/setup.groovy
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,18 +20,6 @@
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-String expected = "1\r\nchild"
-for ( String name : [ "test.txt", "mac2win.txt" ] )
-{
-    File file = new File( basedir, "child/target/child-1-src/" + name )
-    if ( !file.exists() )
-    {
-        throw new FileNotFoundException( "Filtered file from file-set: " + file + " is missing." )
-    }
-
-    String actual = new String( Files.readAllBytes( file.toPath() ), StandardCharsets.UTF_8 )
-    assert actual == expected :
-            "Contents of " + name + ": '" + actual + "' should contain exactly one windows newline: '\\r\\n'."
-}
-
-return true;
+File input = new File( basedir, "child/src/main/assembly-resources/mac2win.txt" )
+Files.write( input.toPath(), '${project.version}\r${project.artifactId}'.getBytes( StandardCharsets.UTF_8 ) )
+return true

--- a/src/it/projects/file-sets/multimodule-win-lineEndings/verify.groovy
+++ b/src/it/projects/file-sets/multimodule-win-lineEndings/verify.groovy
@@ -24,10 +24,7 @@ String expected = "1\r\nchild"
 for ( String name : [ "test.txt", "mac2win.txt" ] )
 {
     File file = new File( basedir, "child/target/child-1-src/" + name )
-    if ( !file.exists() )
-    {
-        throw new FileNotFoundException( "Filtered file from file-set: " + file + " is missing." )
-    }
+    assert file.exists() : "Filtered file from file-set: " + file + " is missing."
 
     String actual = new String( Files.readAllBytes( file.toPath() ), StandardCharsets.UTF_8 )
     assert actual == expected :

--- a/src/main/java/org/apache/maven/plugins/assembly/utils/WindowsLineFeedInputStream.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/utils/WindowsLineFeedInputStream.java
@@ -26,78 +26,81 @@ import java.io.InputStream;
  */
 class WindowsLineFeedInputStream extends InputStream {
 
-    private final InputStream target;
+    private static final int NO_PENDING_BYTE = -2;
+
+    private final InputStream inputStream;
 
     private final boolean ensureLineFeedAtEndOfFile;
-
-    private boolean slashRSeen = false;
-
-    private boolean slashNSeen = false;
 
     private boolean injectSlashN = false;
 
     private boolean eofSeen = false;
 
+    private boolean slashNSeen = false;
+
+    private int pendingByte = NO_PENDING_BYTE;
+
     WindowsLineFeedInputStream(InputStream in, boolean ensureLineFeedAtEndOfFile) {
-        this.target = in;
+        this.inputStream = in;
         this.ensureLineFeedAtEndOfFile = ensureLineFeedAtEndOfFile;
     }
 
-    private int readWithUpdate() throws IOException {
-        final int target = this.target.read();
-        eofSeen = target == -1;
-        if (eofSeen) {
-            return target;
+    private int readTarget() throws IOException {
+        if (pendingByte != NO_PENDING_BYTE) {
+            int result = pendingByte;
+            pendingByte = NO_PENDING_BYTE;
+            return result;
         }
-        slashRSeen = target == '\r';
-        slashNSeen = target == '\n';
+        if (eofSeen) {
+            return -1;
+        }
+
+        final int target = this.inputStream.read();
+        eofSeen = target == -1;
         return target;
     }
 
     @Override
     public int read() throws IOException {
-        if (eofSeen) {
-            return eofGame();
-        } else if (injectSlashN) {
+        if (injectSlashN) {
             injectSlashN = false;
+            slashNSeen = true;
             return '\n';
-        } else {
-            boolean prevWasSlashR = slashRSeen;
-            int target = readWithUpdate();
-            if (eofSeen) {
-                return eofGame();
-            }
-            if (target == '\n') {
-                if (!prevWasSlashR) {
-                    injectSlashN = true;
-                    return '\r';
-                }
-            }
-            return target;
         }
+
+        int target = readTarget();
+        if (target == -1) {
+            return eofGame();
+        }
+
+        slashNSeen = false;
+        if (target == '\r') {
+            int next = readTarget();
+            if (next != '\n' && next != -1) {
+                pendingByte = next;
+            }
+            injectSlashN = true;
+            return '\r';
+        }
+        if (target == '\n') {
+            injectSlashN = true;
+            return '\r';
+        }
+        return target;
     }
 
     private int eofGame() {
-        if (!ensureLineFeedAtEndOfFile) {
-            return -1;
-        }
-        if (!slashNSeen && !slashRSeen) {
-            slashRSeen = true;
+        if (ensureLineFeedAtEndOfFile && !slashNSeen) {
+            injectSlashN = true;
             return '\r';
         }
-        if (!slashNSeen) {
-            slashRSeen = false;
-            slashNSeen = true;
-            return '\n';
-        } else {
-            return -1;
-        }
+        return -1;
     }
 
     @Override
     public void close() throws IOException {
         super.close();
-        target.close();
+        inputStream.close();
     }
 
     @Override

--- a/src/test/java/org/apache/maven/plugins/assembly/utils/WindowsLineFeedInputStreamTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/utils/WindowsLineFeedInputStreamTest.java
@@ -54,8 +54,23 @@ class WindowsLineFeedInputStreamTest {
     }
 
     @Test
-    void malformed() throws Exception {
-        assertEquals("a\rbc", roundtrip("a\rbc", false));
+    void crOnly() throws Exception {
+        assertEquals("a\r\nbc", roundtrip("a\rbc", false));
+    }
+
+    @Test
+    void crAtEnd() throws Exception {
+        assertEquals("a\r\n", roundtrip("a\r", false));
+    }
+
+    @Test
+    void consecutiveCrCharacters() throws Exception {
+        assertEquals("a\r\n\r\nb", roundtrip("a\r\rb", false));
+    }
+
+    @Test
+    void mixedLineEndings() throws Exception {
+        assertEquals("a\r\nb\r\nc\r\nd", roundtrip("a\rb\nc\r\nd", false));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1154.

## Summary

Normalize old Mac CR-only line endings to CRLF when an assembly file set uses
`<lineEnding>crlf</lineEnding>` (or its `windows`/`dos` aliases).

`WindowsLineFeedInputStream` now treats CR, LF, and CRLF as logical line
separators and emits exactly one CRLF for each. A one-byte lookahead preserves
the byte following a lone CR, while the existing option to add a final line
ending at EOF continues to work without adding a duplicate CRLF.

## Root cause

The previous stream converted a bare LF to CRLF and recognized an existing
CRLF, but passed a CR not followed by LF through unchanged. As a result,
filtering the CR-only source from the issue reproducer still left CR-only line
endings in the assembled file despite the requested `crlf` setting.

Unit tests cover lone and trailing CRs, consecutive CRs, and mixed CR/LF/CRLF
input. The existing Windows-line-ending Invoker project now also generates a
CR-only resource during setup, avoiding source-control newline conversion, and
verifies the assembled bytes exactly.

## Compatibility and verification

- Maven 3.6.3 with Java 8:
  `mvn -DminimalMavenBuildVersion=3.6.3 -Prun-its clean verify` passed with
  271 unit tests and all 150 Invoker builds.
- Maven 3.9.16 with Java 21:
  `mvn -Prun-its clean verify` passed with 271 unit tests and all 150 Invoker
  builds.
- Maven 4.0.0-rc-5 with Java 21: all 271 unit tests passed, and the focused
  Invoker run containing this regression passed. The full Invoker run passed
  145 of 150 projects; the remaining five are unrelated parent-cycle fixtures
  also failing on `master`.

Before the implementation change, the new focused unit coverage failed for
all four CR-only/mixed-ending cases.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
