### PR TITLE
Use project repositories when building dependency POMs

### DIFF
--- a/src/it/projects/bugs/massembly-1306/pom.xml
+++ b/src/it/projects/bugs/massembly-1306/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugin.assembly.test</groupId>
+  <artifactId>massembly-1306</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+
+  <repositories>
+    <repository>
+      <id>massembly-1306-repository</id>
+      <url>file://${project.basedir}/remote-repository</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its</groupId>
+      <artifactId>massembly-1306-dependency</artifactId>
+      <version>1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/dist.xml</descriptor>
+          </descriptors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-1306/setup.groovy
+++ b/src/it/projects/bugs/massembly-1306/setup.groovy
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.security.MessageDigest
+import java.util.jar.JarOutputStream
+
+File artifactDirectory =
+        new File(basedir, "remote-repository/org/apache/maven/its/massembly-1306-dependency/1")
+assert artifactDirectory.mkdirs() || artifactDirectory.isDirectory()
+
+File pom = new File(artifactDirectory, "massembly-1306-dependency-1.pom")
+pom.text = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>massembly-1306-dependency</artifactId>
+  <version>1</version>
+</project>
+"""
+
+File jar = new File(artifactDirectory, "massembly-1306-dependency-1.jar")
+new JarOutputStream(new FileOutputStream(jar)).close()
+
+[pom, jar].each { file ->
+    String sha1 = MessageDigest.getInstance("SHA-1").digest(file.bytes).encodeHex()
+    new File(artifactDirectory, "${file.name}.sha1").text = sha1
+}
+
+return true

--- a/src/it/projects/bugs/massembly-1306/src/assembly/dist.xml
+++ b/src/it/projects/bugs/massembly-1306/src/assembly/dist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>dist</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/src/it/projects/bugs/massembly-1306/verify.groovy
+++ b/src/it/projects/bugs/massembly-1306/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+String unavailableRepositoryMessage =
+        "cached from a remote repository ID that is unavailable in current build context"
+assert !new File(basedir, "build.log").text.contains(unavailableRepositoryMessage)
+
+new ZipFile(new File(basedir, "target/massembly-1306-1-dist.zip")).withCloseable { zip ->
+    assert zip.getEntry("lib/massembly-1306-dependency-1.jar") != null
+}

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTask.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTask.java
@@ -167,6 +167,7 @@ public class AddDependencySetsTask {
 
     private ProjectBuildingRequest getProjectBuildingRequest(AssemblerConfigurationSource configSource) {
         return new DefaultProjectBuildingRequest(configSource.getMavenSession().getProjectBuildingRequest())
+                .setRemoteRepositories(project.getRemoteArtifactRepositories())
                 .setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL)
                 .setProcessPlugins(false);
     }

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTaskTest.java
@@ -28,8 +28,6 @@ import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.execution.MavenSession;
@@ -120,12 +118,10 @@ class AddDependencySetsTaskTest {
         when(depArtifact.getGroupId()).thenReturn("GROUPID");
 
         depProject.setArtifact(depArtifact);
-        ArtifactRepository remoteRepository = new MavenArtifactRepository(
-                "project-repository",
-                "https://repository.example/",
-                new DefaultRepositoryLayout(),
-                new ArtifactRepositoryPolicy(),
-                new ArtifactRepositoryPolicy());
+        MavenArtifactRepository remoteRepository = new MavenArtifactRepository();
+        remoteRepository.setId("project-repository");
+        remoteRepository.setUrl("https://repository.example/");
+        remoteRepository.setLayout(new DefaultRepositoryLayout());
         depProject.setRemoteArtifactRepositories(Collections.singletonList(remoteRepository));
 
         ProjectBuildingResult pbr = mock(ProjectBuildingResult.class);

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/task/AddDependencySetsTaskTest.java
@@ -28,6 +28,10 @@ import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugins.assembly.AssemblerConfigurationSource;
@@ -116,6 +120,13 @@ class AddDependencySetsTaskTest {
         when(depArtifact.getGroupId()).thenReturn("GROUPID");
 
         depProject.setArtifact(depArtifact);
+        ArtifactRepository remoteRepository = new MavenArtifactRepository(
+                "project-repository",
+                "https://repository.example/",
+                new DefaultRepositoryLayout(),
+                new ArtifactRepositoryPolicy(),
+                new ArtifactRepositoryPolicy());
+        depProject.setRemoteArtifactRepositories(Collections.singletonList(remoteRepository));
 
         ProjectBuildingResult pbr = mock(ProjectBuildingResult.class);
         when(pbr.getProject()).thenReturn(depProject);
@@ -164,7 +175,11 @@ class AddDependencySetsTaskTest {
         verify(session, times(2)).getUserProperties();
         verify(session, times(2)).getSystemProperties();
 
-        verify(projectBuilder).build(any(Artifact.class), any(ProjectBuildingRequest.class));
+        ArgumentCaptor<ProjectBuildingRequest> request = ArgumentCaptor.forClass(ProjectBuildingRequest.class);
+        verify(projectBuilder).build(any(Artifact.class), request.capture());
+        assertEquals(
+                "project-repository",
+                request.getValue().getRemoteRepositories().get(0).getId());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1306.

## Summary

Use the repositories configured for the project being assembled when the
Assembly Plugin rebuilds dependency projects to obtain their POM metadata.

This prevents Maven 3 from repeatedly warning that a locally cached dependency
POM came from a repository unavailable in the current build context when that
repository is declared by the assembly project rather than in the session's
initial project-building request.

## Root cause

`AddDependencySetsTask` creates a `ProjectBuildingRequest` for each dependency
by copying the Maven session request. That copied request does not necessarily
contain repositories contributed by the effective assembly project. Maven
therefore attempted to verify the dependency POM against Central alone,
emitted the unavailable-repository warning, and fell back to a stub project.

The copied request now uses `project.getRemoteArtifactRepositories()`, retaining
the repositories Maven calculated for the project being assembled.

The unit test verifies that these repositories reach `ProjectBuilder`. The new
Invoker project creates a dependency in a private file repository, verifies
that the warning is absent, and checks that the dependency JAR remains present
in the resulting archive. Before the implementation change, this integration
test failed because the warning appeared twice.

## Compatibility and verification

- Maven 3.9.16 with Java 21: `mvn clean verify` passed with 268 unit tests.
- Maven 3.9.16 with Java 21: the focused MASSEMBLY-1306 Invoker test passed.
- Maven 4.0.0-rc-5 with Java 21: the focused MASSEMBLY-1306 Invoker test passed.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
