### PR TITLE
Improve module-set integration test coverage

### DIFF
--- a/src/it/projects/dependency-sets/using-moduleSet-implied-depSet/verify.bsh
+++ b/src/it/projects/dependency-sets/using-moduleSet-implied-depSet/verify.bsh
@@ -23,6 +23,7 @@ boolean result = true;
 
 result = result && new File( basedir, "module-b/target/module-b-1.0-SNAPSHOT-bin/modules/jdom-1.0.jar" ).exists();
 result = result && new File( basedir, "module-b/target/module-b-1.0-SNAPSHOT-bin/modules/velocity-1.4.jar" ).exists();
+result = result && new File( basedir, "module-b/target/module-b-1.0-SNAPSHOT-bin/modules/velocity-dep-1.4.jar" ).exists();
 
 result = result && new File( basedir, "module-b/target/module-b-1.0-SNAPSHOT-bin/modules/module-a.jar" ).exists();
 result = result && new File( basedir, "module-b/target/module-b-1.0-SNAPSHOT-bin/modules/module-b.jar" ).exists();

--- a/src/it/projects/multimodule/module-attachment-classifier/assembly/pom.xml
+++ b/src/it/projects/multimodule/module-attachment-classifier/assembly/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.assembly.it</groupId>
+    <artifactId>module-attachment-classifier</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>assembly</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/assembly/bin.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/multimodule/module-attachment-classifier/assembly/src/main/assembly/bin.xml
+++ b/src/it/projects/multimodule/module-attachment-classifier/assembly/src/main/assembly/bin.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>bin</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>org.apache.maven.plugins.assembly.it:producer</include>
+      </includes>
+      <binaries>
+        <attachmentClassifier>tests</attachmentClassifier>
+        <includeDependencies>false</includeDependencies>
+        <outputDirectory>modules</outputDirectory>
+        <outputFileNameMapping>${module.artifactId}-${module.classifier}.${module.extension}</outputFileNameMapping>
+        <unpack>false</unpack>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+</assembly>

--- a/src/it/projects/multimodule/module-attachment-classifier/pom.xml
+++ b/src/it/projects/multimodule/module-attachment-classifier/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <groupId>org.apache.maven.plugins.assembly.it</groupId>
+  <artifactId>module-attachment-classifier</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>producer</module>
+    <module>assembly</module>
+  </modules>
+</project>

--- a/src/it/projects/multimodule/module-attachment-classifier/producer/pom.xml
+++ b/src/it/projects/multimodule/module-attachment-classifier/producer/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.assembly.it</groupId>
+    <artifactId>module-attachment-classifier</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>producer</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-tests</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/multimodule/module-attachment-classifier/producer/src/test/resources/attachment-marker.txt
+++ b/src/it/projects/multimodule/module-attachment-classifier/producer/src/test/resources/attachment-marker.txt
@@ -1,0 +1,1 @@
+This file is present only in the attached test JAR.

--- a/src/it/projects/multimodule/module-attachment-classifier/verify.groovy
+++ b/src/it/projects/multimodule/module-attachment-classifier/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.JarFile
+
+def modulesDirectory = new File(basedir, 'assembly/target/assembly-1.0-bin/modules')
+def attachment = new File(modulesDirectory, 'producer-tests.jar')
+
+assert attachment.isFile() : "The attached test JAR is missing: ${attachment}"
+
+def jar = new JarFile(attachment)
+try {
+    assert jar.getEntry('attachment-marker.txt') != null :
+            'The selected artifact does not contain the attachment marker.'
+} finally {
+    jar.close()
+}
+
+assert !new File(modulesDirectory, 'producer.jar').exists() :
+        'The main module artifact was included instead of its attachment.'

--- a/src/it/projects/multimodule/module-attachment-classifier/verify.groovy
+++ b/src/it/projects/multimodule/module-attachment-classifier/verify.groovy
@@ -24,6 +24,10 @@ def attachment = new File(modulesDirectory, 'producer-tests.jar')
 
 assert attachment.isFile() : "The attached test JAR is missing: ${attachment}"
 
+def moduleArtifacts = modulesDirectory.listFiles()*.name.sort()
+assert moduleArtifacts == ['producer-tests.jar'] :
+        "Expected only the attached test JAR, but found: ${moduleArtifacts}"
+
 def jar = new JarFile(attachment)
 try {
     assert jar.getEntry('attachment-marker.txt') != null :
@@ -31,6 +35,3 @@ try {
 } finally {
     jar.close()
 }
-
-assert !new File(modulesDirectory, 'producer.jar').exists() :
-        'The main module artifact was included instead of its attachment.'

--- a/src/it/projects/multimodule/multimodule-wholeReactorFromChild/child1/pom.xml
+++ b/src/it/projects/multimodule/multimodule-wholeReactorFromChild/child1/pom.xml
@@ -35,5 +35,11 @@ under the License.
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <!-- This runtime dependency must be excluded by includeDependencies=false. -->
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/it/projects/multimodule/multimodule-wholeReactorFromChild/verify.bsh
+++ b/src/it/projects/multimodule/multimodule-wholeReactorFromChild/verify.bsh
@@ -18,6 +18,7 @@
  */
 
 import java.io.*;
+import java.util.Arrays;
 
 boolean result = true;
 

--- a/src/it/projects/multimodule/multimodule-wholeReactorFromChild/verify.bsh
+++ b/src/it/projects/multimodule/multimodule-wholeReactorFromChild/verify.bsh
@@ -39,4 +39,14 @@ if ( new File( basedir, "child4/target/child4-1.0-bin/lib/child2.jar" ).exists()
     result = false;
 }
 
+File libDirectory = new File( basedir, "child4/target/child4-1.0-bin/lib" );
+File[] includedArtifacts = libDirectory.listFiles();
+
+if ( includedArtifacts == null || includedArtifacts.length != 2 )
+{
+    System.out.println( "Only the two selected module artifacts should be present when includeDependencies=false." );
+    System.out.println( "Files found: " + Arrays.toString( includedArtifacts ) );
+    result = false;
+}
+
 return result;


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

This PR strengthens integration coverage for documented module-set binary behavior without changing production code.

It verifies that:

- `includeDependencies=false` excludes an actual runtime dependency while retaining selected module artifacts;
- `attachmentClassifier` selects an attached classified artifact instead of the module's main artifact; and
- the implied dependency set includes an artifact that is reachable only transitively.

Validation:

- `mvn verify` — 268 tests passed.
- `mvn -Prun-its verify` — 151 Invoker projects passed.
- The affected Invoker projects also passed focused runs with Maven 3.6.3, Maven 3.9.16, and Maven 4.0.0-rc-5.

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
