### PR TITLE
[MASSEMBLY-1001] Include attachments from POM modules

### DIFF
--- a/src/it/projects/bugs/massembly-1001/assembly/pom.xml
+++ b/src/it/projects/bugs/massembly-1001/assembly/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.assembly.it</groupId>
+    <artifactId>massembly-1001</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>assembly</artifactId>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>assemble</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptors>
+            <descriptor>src/main/assembly/bin.xml</descriptor>
+          </descriptors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-1001/assembly/src/main/assembly/bin.xml
+++ b/src/it/projects/bugs/massembly-1001/assembly/src/main/assembly/bin.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>bin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>org.apache.maven.plugins.assembly.it:site</include>
+      </includes>
+      <binaries>
+        <attachmentClassifier>site</attachmentClassifier>
+        <includeDependencies>false</includeDependencies>
+        <outputDirectory>documentation</outputDirectory>
+        <unpack>true</unpack>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+</assembly>

--- a/src/it/projects/bugs/massembly-1001/pom.xml
+++ b/src/it/projects/bugs/massembly-1001/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <groupId>org.apache.maven.plugins.assembly.it</groupId>
+  <artifactId>massembly-1001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>site</module>
+    <module>assembly</module>
+  </modules>
+</project>

--- a/src/it/projects/bugs/massembly-1001/site/pom.xml
+++ b/src/it/projects/bugs/massembly-1001/site/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.assembly.it</groupId>
+    <artifactId>massembly-1001</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>site</artifactId>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-site</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>site</classifier>
+              <classesDirectory>${project.basedir}/src/site-content</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/bugs/massembly-1001/site/src/site-content/site-marker.txt
+++ b/src/it/projects/bugs/massembly-1001/site/src/site-content/site-marker.txt
@@ -1,0 +1,1 @@
+This content comes from an artifact attached to a POM-packaged module.

--- a/src/it/projects/bugs/massembly-1001/verify.groovy
+++ b/src/it/projects/bugs/massembly-1001/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+def archive = new File(basedir, 'assembly/target/assembly-1.0-bin.zip')
+assert archive.isFile() : "The assembly archive is missing: ${archive}"
+
+def zip = new ZipFile(archive)
+try {
+    assert zip.getEntry('documentation/site-marker.txt') != null :
+            'The attached site artifact was not unpacked into the assembly.'
+} finally {
+    zip.close()
+}

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhase.java
@@ -220,11 +220,14 @@ public class ModuleSetAssemblyPhase implements AssemblyArchiverPhase, PhaseOrder
             return;
         }
 
-        final Set<MavenProject> moduleProjects = new LinkedHashSet<>();
-
-        MavenProjects.select(projects, "pom", log(LOGGER), addTo(moduleProjects));
-
         final String classifier = binaries.getAttachmentClassifier();
+
+        final Set<MavenProject> moduleProjects = new LinkedHashSet<>();
+        if (classifier == null) {
+            MavenProjects.select(projects, "pom", log(LOGGER), addTo(moduleProjects));
+        } else {
+            moduleProjects.addAll(projects);
+        }
 
         final Map<MavenProject, Artifact> chosenModuleArtifacts = new HashMap<>();
 

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhaseTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/phase/ModuleSetAssemblyPhaseTest.java
@@ -338,7 +338,7 @@ class ModuleSetAssemblyPhaseTest {
     }
 
     @Test
-    void addModuleBinariesShouldAddOneModuleAttachmentArtifactAndNoDeps() throws Exception {
+    void addModuleBinariesShouldAddOnePomModuleAttachmentArtifactAndNoDeps() throws Exception {
         final AssemblerConfigurationSource configSource = mock(AssemblerConfigurationSource.class);
         when(configSource.getFinalName()).thenReturn("final-name");
 
@@ -363,6 +363,7 @@ class ModuleSetAssemblyPhaseTest {
         binaries.setAttachmentClassifier("test");
 
         final MavenProject project = createProject("group", "artifact", "version", null);
+        project.setPackaging("pom");
         project.addAttachedArtifact(artifact);
 
         final Set<MavenProject> projects = singleton(project);


### PR DESCRIPTION
Fixes #1208.

POM-packaged reactor modules are currently removed from a module set before
`attachmentClassifier` is examined. This prevents the assembly from using a
matching attached artifact even though POM projects can legitimately produce
classified artifacts.

This change retains POM modules when a classifier is requested and lets the
existing attachment lookup select the artifact or report a missing attachment.
POM modules remain filtered when the module set selects main project artifacts,
preserving the behavior introduced for structural reactor projects without a
main binary.

The regression test builds a POM-packaged reactor module that attaches a
`site`-classified JAR and verifies that a sibling assembly module can select and
unpack it.

Validation:

- Maven 3.9.16 with JDK 21: `mvn -Prun-its clean verify` — 268 unit tests and
  151 Invoker builds passed.
- Maven 4.0.0-rc-5 with JDK 21: focused MASSEMBLY-1001 Invoker test passed.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
