### PR TITLE
Make the single goal m2e-friendly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,11 @@ under the License.
       <artifactId>plexus-interpolation</artifactId>
       <version>1.29</version>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-build-api</artifactId>
+      <version>1.2.0</version>
+    </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/org/apache/maven/plugins/assembly/archive/DefaultAssemblyArchiver.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/DefaultAssemblyArchiver.java
@@ -57,6 +57,7 @@ import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarLongFileMode;
 import org.codehaus.plexus.archiver.war.WarArchiver;
 import org.codehaus.plexus.archiver.zip.AbstractZipArchiver;
+import org.codehaus.plexus.build.BuildContext;
 import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ConfigurationListener;
@@ -97,18 +98,22 @@ public class DefaultAssemblyArchiver implements AssemblyArchiver {
 
     private final BasicComponentConfigurator configurator;
 
+    private final BuildContext buildContext;
+
     @Inject
     public DefaultAssemblyArchiver(
             ArchiverManager archiverManager,
             List<AssemblyArchiverPhase> assemblyPhases,
             Map<String, ContainerDescriptorHandler> containerDescriptorHandlers,
             PlexusContainer container,
-            BasicComponentConfigurator configurator) {
+            BasicComponentConfigurator configurator,
+            BuildContext buildContext) {
         this.archiverManager = requireNonNull(archiverManager);
         this.assemblyPhases = requireNonNull(assemblyPhases);
         this.containerDescriptorHandlers = requireNonNull(containerDescriptorHandlers);
         this.container = requireNonNull(container);
         this.configurator = requireNonNull(configurator);
+        this.buildContext = requireNonNull(buildContext);
     }
 
     private List<AssemblyArchiverPhase> sortedPhases() {
@@ -174,6 +179,7 @@ public class DefaultAssemblyArchiver implements AssemblyArchiver {
             }
 
             archiver.createArchive();
+            buildContext.refresh(destFile);
         } catch (final ArchiverException | IOException e) {
             throw new ArchiveCreationException(
                     "Error creating assembly archive " + assembly.getId() + ": " + e.getMessage(), e);

--- a/src/test/java/org/apache/maven/plugins/assembly/archive/DefaultAssemblyArchiverTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/archive/DefaultAssemblyArchiverTest.java
@@ -44,6 +44,7 @@ import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarLongFileMode;
 import org.codehaus.plexus.archiver.war.WarArchiver;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
+import org.codehaus.plexus.build.BuildContext;
 import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
 import org.codehaus.plexus.interpolation.fixed.FixedStringSearchInterpolator;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +81,8 @@ public class DefaultAssemblyArchiverTest {
 
     private BasicComponentConfigurator configurator;
 
+    private BuildContext buildContext;
+
     public static void setupInterpolators(AssemblerConfigurationSource configSource) {
         when(configSource.getRepositoryInterpolator()).thenReturn(FixedStringSearchInterpolator.create());
         when(configSource.getCommandLinePropsInterpolator()).thenReturn(FixedStringSearchInterpolator.create());
@@ -98,6 +101,7 @@ public class DefaultAssemblyArchiverTest {
         this.archiverManager = mock(ArchiverManager.class);
         this.container = new DefaultPlexusContainer();
         this.configurator = new BasicComponentConfigurator();
+        this.buildContext = mock(BuildContext.class);
     }
 
     @Test
@@ -162,6 +166,7 @@ public class DefaultAssemblyArchiverTest {
         verify(archiver).setOverrideGroupName("root");
 
         verify(archiverManager).getArchiver("zip");
+        verify(buildContext).refresh(new File(outDir, "full-name.zip"));
     }
 
     @Test
@@ -352,7 +357,8 @@ public class DefaultAssemblyArchiverTest {
     }
 
     private DefaultAssemblyArchiver createSubject(final List<AssemblyArchiverPhase> phases) {
-        return new DefaultAssemblyArchiver(archiverManager, phases, Collections.emptyMap(), container, configurator);
+        return new DefaultAssemblyArchiver(
+                archiverManager, phases, Collections.emptyMap(), container, configurator, buildContext);
     }
 
     private static final class TestTarArchiver extends TarArchiver {


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Summary

- Inject `org.codehaus.plexus.build.BuildContext` into the assembly archiver and refresh the completed archive.
- Verify that archive creation refreshes the output path.

Fixes #1150

## Why

When an m2e lifecycle mapping explicitly enables `assembly:single`, the plugin can create or replace an archive without notifying the Eclipse workspace. Calling `BuildContext.refresh(File)` after archive creation makes the generated output visible to BuildContext-aware consumers.

This PR deliberately does not embed IDE-specific lifecycle-mapping metadata. Whether m2e executes or ignores the goal remains a project, parent-POM, or m2e policy decision.

The Codehaus `plexus-build-api` implementation is Sisu-indexed and retains its legacy API bridge, so the same constructor injection also works in ordinary Maven CLI builds.

## Validation

- Maven 3.9.16 / JDK 21: `mvn -Prun-its clean verify` — 268 unit tests and all 150 integration tests passed.
- Maven 3.6.3 / JDK 8: `mvn -Denforcer.skip=true -Prun-its clean verify` — 268 unit tests and all 150 integration tests passed. The enforcer skip is required because the current development parent requires Maven 3.9 to build.
- Maven 4.0.0-rc-5 / JDK 21: the focused `DefaultAssemblyArchiverTest` and packaging passed. The full run passed all 268 unit tests and 144 of 150 integration tests; the remaining six existing fixtures fail during Maven 4 model construction with `The parents form a cycle`, before this plugin executes.
- After removing the lifecycle metadata, `mvn clean -Dtest=DefaultAssemblyArchiverTest package` passes all 8 focused tests, Checkstyle, Spotless, RAT, and packaging; the resulting plugin JAR contains no `META-INF/m2e/lifecycle-mapping-metadata.xml`.
