### PR TITLE
[MASSEMBLY-896] Allow configuring assembly descriptors via property

### DIFF
--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/first.txt
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/first.txt
@@ -1,0 +1,1 @@
+first descriptor

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/invoker.properties
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=org.apache.maven.plugins:maven-assembly-plugin:${project.version}:single

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/pom.xml
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugin.assembly.test</groupId>
+    <artifactId>it-project-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>descriptors-cli-property</artifactId>
+  <version>1</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <attach>false</attach>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/second.txt
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/second.txt
@@ -1,0 +1,1 @@
+second descriptor

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/src/assembly/first.xml
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/src/assembly/first.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3
+                              https://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>first</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <files>
+    <file>
+      <source>first.txt</source>
+    </file>
+  </files>
+</assembly>

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/src/assembly/second.xml
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/src/assembly/second.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3
+                              https://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>second</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <files>
+    <file>
+      <source>second.txt</source>
+    </file>
+  </files>
+</assembly>

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/test.properties
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+assembly.descriptors=src/assembly/first.xml,src/assembly/second.xml

--- a/src/it/projects/mojo-configuration/descriptorsCLIProperty/verify.groovy
+++ b/src/it/projects/mojo-configuration/descriptorsCLIProperty/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+[
+        'first': 'first.txt',
+        'second': 'second.txt'
+].each { id, entry ->
+    File archive = new File(basedir, "target/descriptors-cli-property-1-${id}.zip")
+    assert archive.isFile()
+
+    try (ZipFile zip = new ZipFile(archive)) {
+        assert zip.getEntry(entry) != null
+    }
+}
+
+return true

--- a/src/main/java/org/apache/maven/plugins/assembly/mojos/AbstractAssemblyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/mojos/AbstractAssemblyMojo.java
@@ -157,7 +157,7 @@ public abstract class AbstractAssemblyMojo extends AbstractMojo implements Assem
     /**
      * A list of descriptor files to generate from.
      */
-    @Parameter
+    @Parameter(property = "assembly.descriptors")
     private String[] descriptors;
 
     /**


### PR DESCRIPTION
## Summary

Expose the `descriptors` Mojo parameter as the `assembly.descriptors` user
property. This allows custom assembly descriptors to be selected when invoking
`assembly:single` directly from the command line.

Maven converts a comma-separated property value to the existing `String[]`
parameter. The integration test supplies two descriptor paths through one user
property and verifies the archive produced by each descriptor.

Fixes #1105

## Validation

- `mvn verify` with Maven 3.9.16 and JDK 21: 268 tests passed.
- `mvn -Prun-its verify` with Maven 3.9.16 and JDK 21: 151 Invoker builds passed.
- Focused integration test with Maven 3.6.3 and JDK 8.
- Focused integration test with Maven 4.0.0-rc-5 and JDK 21.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
