### PR TITLE
Fix #1275: stop using PrintWriter in AbstractLineAggregatingHandler to avoid swallowing IOExceptions

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
@@ -22,9 +22,10 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +52,17 @@ abstract class AbstractLineAggregatingHandler implements ContainerDescriptorHand
         return "UTF-8";
     }
 
+    /**
+     * Creates the output stream the aggregated lines are written to.
+     *
+     * @param path the path of the temporary file the aggregated content is written to
+     * @return the output stream to write the aggregated content to
+     * @throws IOException if the output stream cannot be created
+     */
+    protected OutputStream newAggregationOutputStream(final Path path) throws IOException {
+        return Files.newOutputStream(path);
+    }
+
     @Override
     public void finalizeArchiveCreation(final Archiver archiver) {
         // this will prompt the isSelected() call, below, for all resources added to the archive.
@@ -75,10 +87,11 @@ abstract class AbstractLineAggregatingHandler implements ContainerDescriptorHand
                 f = Files.createTempFile("assembly-" + fname, ".tmp").toFile();
                 f.deleteOnExit();
 
-                try (PrintWriter writer =
-                        new PrintWriter(new OutputStreamWriter(Files.newOutputStream(f.toPath()), getEncoding()))) {
+                try (OutputStreamWriter writer =
+                        new OutputStreamWriter(newAggregationOutputStream(f.toPath()), getEncoding())) {
                     for (final String line : entry.getValue()) {
-                        writer.println(line);
+                        writer.write(line);
+                        writer.write(System.lineSeparator());
                     }
                 }
             } catch (final IOException e) {

--- a/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
@@ -91,7 +91,7 @@ abstract class AbstractLineAggregatingHandler implements ContainerDescriptorHand
                         new OutputStreamWriter(newAggregationOutputStream(f.toPath()), getEncoding())) {
                     for (final String line : entry.getValue()) {
                         writer.write(line);
-                        writer.write(System.lineSeparator());
+                        writer.write('\n');
                     }
                 }
             } catch (final IOException e) {

--- a/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
@@ -59,7 +59,7 @@ abstract class AbstractLineAggregatingHandler implements ContainerDescriptorHand
      * @return the output stream to write the aggregated content to
      * @throws IOException if the output stream cannot be created
      */
-    protected OutputStream newAggregationOutputStream(final Path path) throws IOException {
+    OutputStream newAggregationOutputStream(final Path path) throws IOException {
         return Files.newOutputStream(path);
     }
 

--- a/src/test/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandlerTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandlerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.assembly.filter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.diags.NoOpArchiver;
+import org.codehaus.plexus.components.io.fileselectors.FileInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AbstractLineAggregatingHandlerTest {
+
+    @Test
+    void addToArchiveShouldPropagateIOExceptionWhenAggregationWriteFails() {
+        final AbstractLineAggregatingHandler handler = new AbstractLineAggregatingHandler() {
+            @Override
+            protected String getOutputPathPrefix(final FileInfo fileInfo) {
+                return "";
+            }
+
+            @Override
+            protected boolean fileMatches(final FileInfo fileInfo) {
+                return false;
+            }
+
+            @Override
+            protected OutputStream newAggregationOutputStream(final Path path) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw new IOException("simulated write failure");
+                    }
+
+                    @Override
+                    public void write(final byte[] b, final int off, final int len) throws IOException {
+                        throw new IOException("simulated write failure");
+                    }
+                };
+            }
+        };
+
+        handler.setCatalog(Collections.singletonMap(
+                "META-INF/services/example.Service", Collections.singletonList("com.example.Service")));
+
+        assertThrows(ArchiverException.class, () -> handler.addToArchive(new NoOpArchiver()));
+    }
+}


### PR DESCRIPTION
## Summary

fixes  apache/maven-assembly-plugin#1275.

`AbstractLineAggregatingHandler.addToArchive` wrapped the aggregation output stream in a `PrintWriter`. By design, `PrintWriter` catches `IOException` internally and only records it via `checkError()`. Any write failure during aggregation was therefore silently swallowed, and a truncated or empty aggregated file was added to the archive without any error surfacing.

## Changes

- Replaced `PrintWriter` with `OutputStreamWriter` in `AbstractLineAggregatingHandler.addToArchive`. Write failures now propagate as `IOException` and are wrapped in an `ArchiverException` by the existing catch block.
- Added a small `protected` seam `newAggregationOutputStream(Path)` so the write target can be replaced in tests.
- Added regression test `AbstractLineAggregatingHandlerTest.addToArchiveShouldPropagateIOExceptionWhenAggregationWriteFails` that injects an `OutputStream` which fails on write and asserts that `addToArchive` throws `ArchiverException`.

The test fails on the old code (`PrintWriter` swallows the exception, nothing is thrown) and passes with the fix.

`DefaultMessageHolder` also uses `PrintWriter`, but it wraps an in-memory `StringWriter` which cannot throw `IOException`; it is left unchanged (and `Throwable.printStackTrace` requires a `PrintWriter`).

## Verification

- `mvn verify`: BUILD SUCCESS, 269 tests pass (1 new regression test).
- Behavior of the success path is unchanged: lines are written followed by the platform line separator, identical to the previous `println` behavior.