### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/advanced-descriptor-topics.md.vm
+++ b/src/site/markdown/advanced-descriptor-topics.md.vm
@@ -1,3 +1,10 @@
+---
+title: Advanced Assembly-Descriptor Topics
+author: 
+  - John Casey
+date: 2006-12-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/advanced-module-set-topics.md.vm
+++ b/src/site/markdown/advanced-module-set-topics.md.vm
@@ -1,3 +1,10 @@
+---
+title: Advanced Module-Set Topics
+author: 
+  - John Casey
+date: 2006-12-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/descriptor-refs.md
+++ b/src/site/markdown/descriptor-refs.md
@@ -1,3 +1,12 @@
+---
+title: Predefined Assembly Descriptors
+author: 
+  - Johnny R. Ruiz III <jruiz@exist.com>
+  - Edwin Punzalan
+  - John Casey
+date: 2011-02-07
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/index.md
+++ b/src/site/markdown/examples/index.md
@@ -1,3 +1,10 @@
+---
+title: Examples
+author: 
+  - John Casey
+date: 2008-11-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/multimodule/index.md
+++ b/src/site/markdown/examples/multimodule/index.md
@@ -1,3 +1,10 @@
+---
+title: Multi-Module Examples
+author: 
+  - Edwin Punzalan
+date: 2006-07-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/multimodule/module-binary-inclusion-simple.md.vm
+++ b/src/site/markdown/examples/multimodule/module-binary-inclusion-simple.md.vm
@@ -1,3 +1,10 @@
+---
+title: Including Module Binaries
+author: 
+  - John Casey
+date: 2006-05-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/multimodule/module-source-inclusion-simple.md.vm
+++ b/src/site/markdown/examples/multimodule/module-source-inclusion-simple.md.vm
@@ -1,3 +1,10 @@
+---
+title: Including Module Sources
+author: 
+  - John Casey
+date: 2006-05-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/sharing-descriptors.md.vm
+++ b/src/site/markdown/examples/sharing-descriptors.md.vm
@@ -1,3 +1,10 @@
+---
+title: Sharing Assembly Descriptors
+author: 
+  - Dennis Lundberg
+date: 2010-11-08
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/single/filtering-some-distribution-files.md.vm
+++ b/src/site/markdown/examples/single/filtering-some-distribution-files.md.vm
@@ -1,3 +1,10 @@
+---
+title: Filtering Some Distribution Files
+author: 
+  - Edwin Punzalan
+date: 2006-07-26
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/single/including-and-excluding-artifacts.md
+++ b/src/site/markdown/examples/single/including-and-excluding-artifacts.md
@@ -1,3 +1,10 @@
+---
+title: Including and Excluding Artifacts
+author: 
+  - Barrie Treloar
+date: 2006-07-31
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/single/index.md
+++ b/src/site/markdown/examples/single/index.md
@@ -1,3 +1,10 @@
+---
+title: Single Project Examples
+author: 
+  - Edwin Punzalan
+date: 2006-07-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/single/using-components.md.vm
+++ b/src/site/markdown/examples/single/using-components.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using Component Descriptors
+author: 
+  - Edwin Punzalan
+date: 2006-07-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/single/using-container-descriptor-handlers.md.vm
+++ b/src/site/markdown/examples/single/using-container-descriptor-handlers.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using Container Descriptor Handlers
+author: 
+  - Guillaume Boué
+date: 2017-07-15
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/using-inline-descriptors.md.vm
+++ b/src/site/markdown/examples/using-inline-descriptors.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using Inline Assembly Descriptors
+author: 
+  - Slawomir Jaranowski
+date: 2023-12-17
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,11 @@
+---
+title: Introduction
+author: 
+  - John Casey
+  - Edwin Punzalan
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - John Casey
+date: 2011-02-07
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.