### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/advanced-descriptor-topics.md.vm
+++ b/src/site/markdown/advanced-descriptor-topics.md.vm
@@ -69,7 +69,7 @@ In this example, we'll configure a `dependencySet` so it only includes those `wa
 </assembly>
 ```
 
-#[[#### GOTCHA\!]]#
+#[[#### GOTCHA!]]#
 
 In the above example, any `war` artifacts that happen to have a classifier (not sure why this particular case would happen, but it _is_ possible) will be **skipped**. If you _really_ want to be careful about catching all of the `war` artifacts in your project, you might want to use the following pattern:
 

--- a/src/site/markdown/advanced-module-set-topics.md.vm
+++ b/src/site/markdown/advanced-module-set-topics.md.vm
@@ -31,7 +31,7 @@ As you are no doubt aware, Maven introduces advanced handling of multimodule bui
 
 When constructing an assembly from any parent-level project in a multimodule build, it's possible to process this parent-POM's descendent modules, and include them in some form within the resulting assembly artifact. By default, the entire module hierarchy below the current project is available for inclusion or exclusion. Also, include/exclude patterns for modules are matched using the artifact-matching rules explained in the **Advanced Assembly-Descriptor Topics** document.
 
-The following examples describe how to select certain modules in the project hierarchy using basic artifact includes/excludes. It does **not** describe what to do with the selected modules; to learn about the actions available for selected modules, see [including module sources](#Including_Module_Sources) and [including module binaries](#Including_Module_Binaries) below. For other, more advanced module-handling options, read on\!
+The following examples describe how to select certain modules in the project hierarchy using basic artifact includes/excludes. It does **not** describe what to do with the selected modules; to learn about the actions available for selected modules, see [including module sources](#Including_Module_Sources) and [including module binaries](#Including_Module_Binaries) below. For other, more advanced module-handling options, read on!
 
 #[[### Example: Select one from a set of child projects]]#
 
@@ -101,7 +101,7 @@ _NOTE: The expression_ `${esc.d}{module.extension}` _is mapped to the file exten
 <a id="Including_Module_Sources"></a>Including Module Sources
 -------------------------------------------------------------
 
-Once you've selected certain modules to be included in the assembly, you have to determine what you want included from each module. This usually depends on the purpose of the assembly. For instance, if you're building a binary assembly, for use in a runtime context, you probably want to include module binaries only (see the [Including\_Module\_Binaries](#Including_Module_Binaries) section below). However, if your assembly is meant to include project sources, either as a reference or to allow users to build your project (or for some other reason altogether), then you're probably interested in the `sources` section of the `moduleSet`.
+Once you've selected certain modules to be included in the assembly, you have to determine what you want included from each module. This usually depends on the purpose of the assembly. For instance, if you're building a binary assembly, for use in a runtime context, you probably want to include module binaries only (see the [Including_Module_Binaries](#Including_Module_Binaries) section below). However, if your assembly is meant to include project sources, either as a reference or to allow users to build your project (or for some other reason altogether), then you're probably interested in the `sources` section of the `moduleSet`.
 
 Processing module sources is a fileSet-based activity. That is, sources are included or excluded based on file-matching patterns, or explicit `fileSet` subsections. **For backward compatibility only**, the `<sources/>` section itself supports `includes` and `excludes` that can help determine which files from a module's directory should be processed. Starting in version 2.2 of the assembly plugin, the `<sources/>` section supports a `<fileSets/>` subsection, which is the preferred way of selecting module-source files for processing.
 
@@ -289,7 +289,7 @@ To accomplish this restructuring, simply use the `excludeSubModuleDirectories` f
 <a id="Including_Module_Binaries"></a>Including Module Binaries
 ---------------------------------------------------------------
 
-**WARNING\!** Using the `binaries` section of a `moduleSet` definition involves some tricky considerations that are a result of the way Maven sorts and executes project builds within a multimodule context. Please read [this FAQ entry](./faq.html#module-binaries) if you decide to use them.
+**WARNING!** Using the `binaries` section of a `moduleSet` definition involves some tricky considerations that are a result of the way Maven sorts and executes project builds within a multimodule context. Please read [this FAQ entry](./faq.html#module-binaries) if you decide to use them.
 
 In cases where your assembly artifact is meant to be used in a runtime context, you'll most likely want to include the binaries from any modules processed by the assembly plugin. This can be as simple as adding the module's jar artifact to your assembly archive; or, it can involve selectively including the dependencies of that module in addition to the module's own jar.
 

--- a/src/site/markdown/examples/multimodule/module-binary-inclusion-simple.md.vm
+++ b/src/site/markdown/examples/multimodule/module-binary-inclusion-simple.md.vm
@@ -24,7 +24,7 @@ Warning
 
 **Warning:** Using the `binaries` section of a `moduleSet` definition involves some tricky considerations that are a result of the way Maven sorts and executes project builds within a multimodule context. Please read [this FAQ entry](../../faq.html#module-binaries) if you decide to use them.
 
-**NOTE:** The new `useAllReactorProjects` flag in the `moduleSet` section allows you to consume module binaries from child modules in a multimodule build. This is an important to resolve the conflict between Maven's build ordering and the old approach to module binaries, where the assembly was build from the parent POM. Please read the FAQ entry above for more information, and read the documentation below (carefully\!) to see the new approach in action.
+**NOTE:** The new `useAllReactorProjects` flag in the `moduleSet` section allows you to consume module binaries from child modules in a multimodule build. This is an important to resolve the conflict between Maven's build ordering and the old approach to module binaries, where the assembly was build from the parent POM. Please read the FAQ entry above for more information, and read the documentation below (carefully!) to see the new approach in action.
 
 Introduction
 ------------
@@ -179,7 +179,7 @@ That POM looks like this:
 
 This POM directs the Assembly Plugin to execute the `single` goal when the build reaches the `package` phase, and tells it to use the `bin.xml` assembly descriptor when executing.
 
-Execute\!
+Execute!
 ---------
 
 To build the assembly, we issue the following command:

--- a/src/site/markdown/examples/multimodule/module-source-inclusion-simple.md.vm
+++ b/src/site/markdown/examples/multimodule/module-source-inclusion-simple.md.vm
@@ -113,7 +113,7 @@ Now, let's review the POM configuration necessary to enable the building of this
 
 This POM simply directs the Assembly Plugin to use the `src.xml` assembly descriptor when executing.
 
-Execute\!
+Execute!
 ---------
 
 To build the assembly, we issue the following command:

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -132,7 +132,7 @@ target/sample-1.0-SNAPSHOT-jar-with-dependencies.jar
 
 Notice the artifact classifier, between the end of the version and the beginning of the file extension, `jar-with-dependencies`. This is the `id` of the assembly descriptor used to create this artifact.
 
-#[[### GOTCHA\!]]#
+#[[### GOTCHA!]]#
 
 In most cases, the `single` goal should be bound to the `package` phase of the build. However, if your assembly doesn't require binaries, or if you need to use one assembly as input for another, you may need to change this. While it's possible to assign the `single` goal to any phase of the build lifecycle, you should be careful to make sure the resources included in your assembly exist before that assembly is created.
 
@@ -177,7 +177,7 @@ Main-Class: org.sample.App
 
 For more information on advanced configuration for the Assembly Plugin, see the [Resources](#Resources) section.
 
-#[[### GOTCHA\!]]#
+#[[### GOTCHA!]]#
 
 At this point, only the `jar` and `war` assembly formats support the `<archive>` configuration element.
 


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.