### PR TITLE
Stop dependabot from updating test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    exclude-paths:
+      - "src/it/**"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot walks the fixture tree and bumps poms whose pinned version is the test input; #1358 and #1359 each fail on the exact IT they touch. Same fix as mojohaus/license-maven-plugin@c43d4ee0, after which that repo's stream of `src/it` PRs stopped.

Supersedes #1358, #1359.

*This change was created with AI assistance.*