### PR TITLE
Fix #1349: complete the aggregation in the container descriptor handlers

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/AbstractLineAggregatingHandler.java
@@ -60,11 +60,11 @@ abstract class AbstractLineAggregatingHandler
     @Override
     public void finalizeArchiveCreation( final Archiver archiver )
     {
-        // this will prompt the isSelected() call, below, for all resources added to the archive.
-        // FIXME: This needs to be corrected in the AbstractArchiver, where
-        // runArchiveFinalizers() is called before regular resources are added...
-        // which is done because the manifest needs to be added first, and the
-        // manifest-creation component is a finalizer in the assembly plugin...
+        // The archiver runs its finalizers before it scans the resources that have
+        // been added so far (see AbstractArchiver.createArchive()), because the
+        // manifest has to be added first. Iterating the added resources up front
+        // applies the file selectors of every added resource collection, which
+        // invokes this handler's isSelected() and collects the content to aggregate.
         for ( final ResourceIterator it = archiver.getResources(); it.hasNext(); )
         {
             it.next();

--- a/src/main/java/org/apache/maven/plugins/assembly/filter/ComponentsXmlArchiverFileFilter.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/ComponentsXmlArchiverFileFilter.java
@@ -141,11 +141,11 @@ public class ComponentsXmlArchiverFileFilter
     @Override
     public void finalizeArchiveCreation( final Archiver archiver )
     {
-        // this will prompt the isSelected() call, below, for all resources added to the archive.
-        // FIXME: This needs to be corrected in the AbstractArchiver, where
-        // runArchiveFinalizers() is called before regular resources are added...
-        // which is done because the manifest needs to be added first, and the
-        // manifest-creation component is a finalizer in the assembly plugin...
+        // The archiver runs its finalizers before it scans the resources that have
+        // been added so far (see AbstractArchiver.createArchive()), because the
+        // manifest has to be added first. Iterating the added resources up front
+        // applies the file selectors of every added resource collection, which
+        // invokes this handler's isSelected() and collects the content to aggregate.
         for ( final ResourceIterator it = archiver.getResources(); it.hasNext(); )
         {
             it.next();

--- a/src/main/java/org/apache/maven/plugins/assembly/filter/SimpleAggregatingDescriptorHandler.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/filter/SimpleAggregatingDescriptorHandler.java
@@ -22,6 +22,7 @@ package org.apache.maven.plugins.assembly.filter;
 import org.apache.maven.plugins.assembly.utils.AssemblyFileUtils;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.ResourceIterator;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.components.io.fileselectors.FileInfo;
@@ -78,6 +79,16 @@ public class SimpleAggregatingDescriptorHandler
     public void finalizeArchiveCreation( final Archiver archiver )
     {
         checkConfig();
+
+        // The archiver runs its finalizers before it scans the resources that have
+        // been added so far (see AbstractArchiver.createArchive()), because the
+        // manifest has to be added first. Iterating the added resources up front
+        // applies the file selectors of every added resource collection, which
+        // invokes this handler's isSelected() and collects the content to aggregate.
+        for ( final ResourceIterator it = archiver.getResources(); it.hasNext(); )
+        {
+            it.next();
+        }
 
         if ( outputPath.endsWith( "/" ) )
         {

--- a/src/test/java/org/apache/maven/plugins/assembly/filter/ComponentsXmlArchiverFileFilterTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/filter/ComponentsXmlArchiverFileFilterTest.java
@@ -31,6 +31,7 @@ import org.codehaus.plexus.archiver.FileSet;
 import org.codehaus.plexus.archiver.ResourceIterator;
 import org.codehaus.plexus.archiver.diags.NoOpArchiver;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
+import org.codehaus.plexus.components.io.resources.PlexusIoFileResourceCollection;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 import org.codehaus.plexus.components.io.resources.PlexusIoResourceCollection;
 import org.codehaus.plexus.util.IOUtil;
@@ -316,6 +317,104 @@ public class ComponentsXmlArchiverFileFilterTest
         assertEquals( "hint2", ( (Text) hint2.selectSingleNode( doc ) ).getText() );
         assertEquals( "impl", ( (Text) implementation2.selectSingleNode( doc ) ).getText() );
 
+    }
+
+    public void testShouldAggregateComponentsFromResourcesAddedToTheArchive()
+        throws Exception
+    {
+        final File dirA = new File( fileManager.createTempDir(), "a" );
+        dirA.mkdirs();
+        final File dirB = new File( fileManager.createTempDir(), "b" );
+        dirB.mkdirs();
+
+        writeComponentDescriptor( dirA, "role1", "impl1" );
+        writeComponentDescriptor( dirB, "role2", "impl2" );
+
+        final ZipArchiver archiver = new ZipArchiver();
+
+        final File archiveFile = fileManager.createTempFile();
+
+        archiver.setDestFile( archiveFile );
+
+        archiver.addResources( componentResourceCollection( dirA, filter ) );
+        archiver.addResources( componentResourceCollection( dirB, filter ) );
+
+        archiver.setArchiveFinalizers( Collections.<ArchiveFinalizer>singletonList( filter ) );
+
+        archiver.createArchive();
+
+        ZipFile zf = null;
+        try
+        {
+            zf = new ZipFile( archiveFile );
+
+            final ZipEntry ze = zf.getEntry( ComponentsXmlArchiverFileFilter.COMPONENTS_XML_PATH );
+
+            assertNotNull( ze );
+
+            final File dest = fileManager.createTempFile();
+            final FileOutputStream out = new FileOutputStream( dest );
+            IOUtil.copy( zf.getInputStream( ze ), out );
+            out.close();
+
+            final String content = IOUtil.toString( new java.io.FileInputStream( dest ) );
+
+            assertTrue( "aggregated components.xml should contain role1",
+                         content.contains( "<role>role1</role>" ) );
+            assertTrue( "aggregated components.xml should contain role2",
+                         content.contains( "<role>role2</role>" ) );
+            assertTrue( "aggregated components.xml should contain impl1",
+                         content.contains( "<implementation>impl1</implementation>" ) );
+            assertTrue( "aggregated components.xml should contain impl2",
+                         content.contains( "<implementation>impl2</implementation>" ) );
+
+            zf.close();
+            zf = null;
+        }
+        finally
+        {
+            try
+            {
+                if ( zf != null )
+                {
+                    zf.close();
+                }
+            }
+            catch ( final IOException e )
+            {
+                // Suppressed.
+            }
+        }
+    }
+
+    private void writeComponentDescriptor( final File baseDir, final String role, final String implementation )
+        throws IOException
+    {
+        final File plexusDir = new File( baseDir, "META-INF/plexus" );
+        plexusDir.mkdirs();
+
+        final File descriptor = new File( plexusDir, "components.xml" );
+
+        final String content = "<component-set><components><component><role>" + role
+            + "</role><implementation>" + implementation
+            + "</implementation></component></components></component-set>";
+
+        final FileOutputStream out = new FileOutputStream( descriptor );
+        out.write( content.getBytes( "UTF-8" ) );
+        out.close();
+    }
+
+    private PlexusIoFileResourceCollection componentResourceCollection(
+        final File baseDir, final org.codehaus.plexus.components.io.fileselectors.FileSelector selector )
+    {
+        final PlexusIoFileResourceCollection collection = new PlexusIoFileResourceCollection();
+
+        collection.setBaseDir( baseDir );
+        collection.setIncludes( new String[] { "**/components.xml" } );
+        collection.setFileSelectors(
+            new org.codehaus.plexus.components.io.fileselectors.FileSelector[] { selector } );
+
+        return collection;
     }
 
     private Xpp3Dom createComponentDom( final ComponentDef def )

--- a/src/test/java/org/apache/maven/plugins/assembly/filter/SimpleAggregatingDescriptorHandlerTest.java
+++ b/src/test/java/org/apache/maven/plugins/assembly/filter/SimpleAggregatingDescriptorHandlerTest.java
@@ -1,0 +1,192 @@
+package org.apache.maven.plugins.assembly.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.TestCase;
+
+import org.apache.maven.plugins.assembly.testutils.TestFileManager;
+import org.codehaus.plexus.archiver.ArchiveFinalizer;
+import org.codehaus.plexus.archiver.zip.ZipArchiver;
+import org.codehaus.plexus.components.io.fileselectors.FileSelector;
+import org.codehaus.plexus.components.io.resources.PlexusIoFileResourceCollection;
+import org.codehaus.plexus.util.IOUtil;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class SimpleAggregatingDescriptorHandlerTest
+    extends TestCase
+{
+
+    private final TestFileManager fileManager =
+        new TestFileManager( "simpleAggregatingDescriptorHandler.test", ".zip" );
+
+    @Override
+    public void tearDown()
+        throws IOException
+    {
+        fileManager.cleanUp();
+    }
+
+    public void testShouldAggregateMatchingFilesIntoOutputPath()
+        throws Exception
+    {
+        final SimpleAggregatingDescriptorHandler handler = new SimpleAggregatingDescriptorHandler();
+        handler.setFilePattern( ".*/file\\.txt" );
+        handler.setOutputPath( "file.txt" );
+
+        final File baseDir = new File( fileManager.createTempDir(), "src" );
+        baseDir.mkdirs();
+        new File( baseDir, "a" ).mkdirs();
+        new File( baseDir, "b" ).mkdirs();
+
+        writeFile( new File( baseDir, "a/file.txt" ), "file A\n" );
+        writeFile( new File( baseDir, "b/file.txt" ), "file B\n" );
+
+        final ZipArchiver archiver = new ZipArchiver();
+        final File archiveFile = fileManager.createTempFile();
+        archiver.setDestFile( archiveFile );
+        archiver.addResources( resourceCollection( baseDir, handler ) );
+        archiver.setArchiveFinalizers( Collections.<ArchiveFinalizer>singletonList( handler ) );
+
+        archiver.createArchive();
+
+        ZipFile zf = null;
+        try
+        {
+            zf = new ZipFile( archiveFile );
+            final ZipEntry entry = zf.getEntry( "file.txt" );
+            assertNotNull( "aggregated file.txt should be present in the archive", entry );
+
+            final String content = readStream( zf.getInputStream( entry ) );
+
+            assertTrue( "aggregated content should contain file A", content.contains( "file A" ) );
+            assertTrue( "aggregated content should contain file B", content.contains( "file B" ) );
+
+            zf.close();
+            zf = null;
+        }
+        finally
+        {
+            closeQuietly( zf );
+        }
+    }
+
+    public void testShouldNotIncludeAggregatedSourcesInArchive()
+        throws Exception
+    {
+        final SimpleAggregatingDescriptorHandler handler = new SimpleAggregatingDescriptorHandler();
+        handler.setFilePattern( ".*/file\\.txt" );
+        handler.setOutputPath( "file.txt" );
+
+        final File baseDir = new File( fileManager.createTempDir(), "src" );
+        baseDir.mkdirs();
+        new File( baseDir, "a" ).mkdirs();
+        new File( baseDir, "b" ).mkdirs();
+
+        writeFile( new File( baseDir, "a/file.txt" ), "file A\n" );
+        writeFile( new File( baseDir, "b/file.txt" ), "file B\n" );
+
+        final ZipArchiver archiver = new ZipArchiver();
+        final File archiveFile = fileManager.createTempFile();
+        archiver.setDestFile( archiveFile );
+        archiver.addResources( resourceCollection( baseDir, handler ) );
+        archiver.setArchiveFinalizers( Collections.<ArchiveFinalizer>singletonList( handler ) );
+
+        archiver.createArchive();
+
+        ZipFile zf = null;
+        try
+        {
+            zf = new ZipFile( archiveFile );
+            int fileCount = 0;
+            final Enumeration<? extends ZipEntry> entries = zf.entries();
+            while ( entries.hasMoreElements() )
+            {
+                final ZipEntry e = entries.nextElement();
+                if ( !e.isDirectory() )
+                {
+                    fileCount++;
+                }
+            }
+            assertEquals( "the matching sources should be excluded, only the aggregated file.txt should remain",
+                          1, fileCount );
+
+            zf.close();
+            zf = null;
+        }
+        finally
+        {
+            closeQuietly( zf );
+        }
+    }
+
+    private PlexusIoFileResourceCollection resourceCollection( final File baseDir, final FileSelector selector )
+    {
+        final PlexusIoFileResourceCollection collection = new PlexusIoFileResourceCollection();
+        collection.setBaseDir( baseDir );
+        collection.setIncludes( new String[] { "**/file.txt" } );
+        collection.setFileSelectors( new FileSelector[] { selector } );
+        return collection;
+    }
+
+    private void writeFile( final File file, final String content )
+        throws IOException
+    {
+        file.getParentFile().mkdirs();
+        final FileOutputStream out = new FileOutputStream( file );
+        out.write( content.getBytes( "UTF-8" ) );
+        out.close();
+    }
+
+    private String readStream( final InputStream in )
+        throws IOException
+    {
+        try
+        {
+            return IOUtil.toString( in );
+        }
+        finally
+        {
+            IOUtil.close( in );
+        }
+    }
+
+    private void closeQuietly( final ZipFile zf )
+    {
+        if ( zf != null )
+        {
+            try
+            {
+                zf.close();
+            }
+            catch ( final IOException e )
+            {
+                // Suppressed.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1349.

The FIXME comments in `AbstractLineAggregatingHandler` and `ComponentsXmlArchiverFileFilter` assumed the resource scan could be moved into plexus-archiver's `AbstractArchiver`, but the scan is required: the archiver runs its finalizers before scanning the added resources, so the file selectors are only applied while iterating.

This PR:
1. **Replaces the misleading FIXME comments** with accurate documentation explaining why the resource iteration is necessary.
2. **Fixes the actual bug in `SimpleAggregatingDescriptorHandler`**: adds the missing resource scan whose absence caused its aggregated file to always be empty.
3. **Adds tests** for both `ComponentsXmlArchiverFileFilter` (verifying end-to-end aggregation from resource collections) and `SimpleAggregatingDescriptorHandler` (verifying aggregation and source exclusion).