### PR TITLE
Drop the Maven 2.0 qualifier from the multimodule package-phase note #1370

### DIFF
--- a/src/site/markdown/examples/multimodule/module-binary-inclusion-simple.md.vm
+++ b/src/site/markdown/examples/multimodule/module-binary-inclusion-simple.md.vm
@@ -197,7 +197,7 @@ mvn clean package
 
 This will ensure that the output directory (normally, `target`), is removed before building the assembly directory.
 
-**Note:** Because of a quirk in Maven 2.0's execution model relating to aggregator goals and the inheritance hierarchy, we need to explicitly execute the package phase ahead of the assembly invocation, to ensure all modules have been built.
+**Note:** Because of a quirk in Maven's execution model relating to aggregator goals and the inheritance hierarchy, we need to explicitly execute the package phase ahead of the assembly invocation, to ensure all modules have been built.
 
 Examining the Output
 --------------------


### PR DESCRIPTION
The multimodule binary-inclusion example still needs `mvn clean package` so reactor modules exist before the assembly runs. That is a Maven aggregator/ordering constraint, not something unique to 2.0.

I dropped the `2.0` qualifier from that note and left the rest.

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [ ] Run `mvn verify` to make sure basic checks pass.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

Docs-only, one sentence.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

Fixes #1370
